### PR TITLE
初回起動時のバグ修正

### DIFF
--- a/app/src/main/java/com/example/discountcalc/CustomAdapters/ResultLayoutAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/CustomAdapters/ResultLayoutAdapter.java
@@ -80,8 +80,8 @@ public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapte
     public void onBindViewHolder(@NonNull ResultViewHolder holder, int position) {
         // この位置のデータセットから要素を取得し、ビューの内容をその要素で置き換える
         holder.discountTextview.setText(String.format(Locale.getDefault(),"%d%%",localData.get(position).getDiscountPer()));
-        holder.discountPriceTextview.setText(String.format(Locale.getDefault(),"%d円",localData.get(position).getDiscountPrice()));
-        holder.priceTextview.setText(String.format(Locale.getDefault(),"%d円",localData.get(position).getAfterPrice()));
+        holder.discountPriceTextview.setText(String.format(Locale.getDefault(),"%,d円",localData.get(position).getDiscountPrice()));
+        holder.priceTextview.setText(String.format(Locale.getDefault(),"%,d円",localData.get(position).getAfterPrice()));
         // 文字のGravityを変更
         holder.discountTextview.setGravity(Gravity.END);
         holder.discountPriceTextview.setGravity(Gravity.END);

--- a/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
@@ -54,6 +54,8 @@ public class ResultListFragment extends Fragment {
     private int price;
     private View view;
 
+    private boolean createDataStoreInstance=false;
+
     private RecyclerView recyclerView;
     private ResultLayoutAdapter resultLayoutAdapter;
     InputMethodManager inputMethodManager;
@@ -102,8 +104,11 @@ public class ResultListFragment extends Fragment {
 
         //　表示数取得
         getViewCountData();
-        // 保存データ取得
-        loadDataStore();
+        // 初回起動時の場合、データストアから値取得しないように(初期値-1になる為)
+        if(!createDataStoreInstance) {
+            // 保存データ取得
+            loadDataStore();
+        }
 
         // 計算
         calcDiscounts();
@@ -161,6 +166,7 @@ public class ResultListFragment extends Fragment {
         if (dataStoreSingleton.getDatastore() == null) {
             datastoreRX = new RxPreferenceDataStoreBuilder(view.getContext(), TAG_STORE_NAME).build();
             createDiscountPreferenceData();
+            createDataStoreInstance=true;
         } else {
             datastoreRX = dataStoreSingleton.getDatastore();
         }
@@ -178,14 +184,12 @@ public class ResultListFragment extends Fragment {
     // DataStoreに割引データの設定を保存
     private void saveDataStore() {
         for(int i=0;i<viewCount;i++){
-
             dataStoreHelper.putIntegerValue(DISCOUNT_KEY + i, discountPers.get(i));
         }
     }
 
     // DataStoreから割引データの設定取得
     private void loadDataStore() {
-        dataStoreHelperInitialize(dataStoreSingleton.getDatastore());
         discountPers=new ArrayList<>();
         configEnums=new ArrayList<>();
         for (int i = 0; i < viewCount; i++) {

--- a/app/src/main/res/layout/result_one_calc_view.xml
+++ b/app/src/main/res/layout/result_one_calc_view.xml
@@ -33,7 +33,7 @@
 
     <TextView
         android:id="@+id/discountPriceLabel"
-        android:layout_width="80dp"
+        android:layout_width="120dp"
         android:layout_height="40dp"
         android:background="@drawable/shape_outer_frame"
         android:gravity="center"


### PR DESCRIPTION
・割引額の表示幅変更
額が大きいと2段になってリストの表示が乱れる問題を少し改善。もっと良い解決策を探す。
・初回起動時のバグ修正
初回起動時、データストアに存在しないデータを取得してしまい、割引率が-1%のみになってしまっていたバグの修正。
・不要な処理を削除。