### PR TITLE
データストアの取得をアクティビティで行うように変更。

### DIFF
--- a/app/src/main/java/com/example/discountcalc/Activity/MainActivity.java
+++ b/app/src/main/java/com/example/discountcalc/Activity/MainActivity.java
@@ -3,25 +3,59 @@ package com.example.discountcalc.Activity;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.datastore.preferences.core.Preferences;
+import androidx.datastore.preferences.rxjava3.RxPreferenceDataStoreBuilder;
+import androidx.datastore.rxjava3.RxDataStore;
+
+import com.example.discountcalc.DataBase.CustomConfigDataStoreSingleton;
+import com.example.discountcalc.DataBase.DataStoreHelper;
+import com.example.discountcalc.R;
 import com.example.discountcalc.databinding.ActivityMainBinding;
+
+import java.util.ArrayList;
 
 public class MainActivity extends AppCompatActivity{
 
+    // 設定ファイル名保存キー("xxx".preferences_pb)
+    private static final String SETTING_DATA = "setting_data";
     private ActivityMainBinding binding;
 
+    // データストア
+    RxDataStore<Preferences> datastoreRX;
+    // データストアのインスタンス取得用
+    CustomConfigDataStoreSingleton dataStoreSingleton;
+
+    // データストアヘルパー取得用
+    private DataStoreHelper dataStoreHelper;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         binding = ActivityMainBinding.inflate(getLayoutInflater());
-        setContentView(binding.getRoot());
 
+        // データストアシングルトン取得
+        getDataStoreInstance();
+        setContentView(binding.getRoot());
     }
 
     @Override
     protected void onStart() {
         super.onStart();
+    }
+
+    // DataStore取得
+    private void getDataStoreInstance() {
+        dataStoreSingleton = CustomConfigDataStoreSingleton.getInstance();
+        // データストアのSingletonが存在してなければ、新たにデータストアを作成
+        if (dataStoreSingleton.getDatastore() == null) {
+            datastoreRX = new RxPreferenceDataStoreBuilder(this, SETTING_DATA).build();
+        } else {
+            // データストア取得
+            datastoreRX = dataStoreSingleton.getDatastore();
+        }
+        // Singletonのデータストアにセット
+        dataStoreSingleton.setDataStore(datastoreRX);
     }
 
 }

--- a/app/src/main/java/com/example/discountcalc/DiscountType.java
+++ b/app/src/main/java/com/example/discountcalc/DiscountType.java
@@ -1,7 +1,14 @@
 package com.example.discountcalc;
 
 public enum DiscountType {
-    None,
-    Custom,
-    Const,
+    None(-1),
+    Custom(0),
+    Const(1);
+
+    private final int value;
+    DiscountType(int value){
+        this.value=value;
+    }
+
+    public int getValue(){return value;}
 }

--- a/app/src/main/java/com/example/discountcalc/DiscountType.java
+++ b/app/src/main/java/com/example/discountcalc/DiscountType.java
@@ -11,4 +11,12 @@ public enum DiscountType {
     }
 
     public int getValue(){return value;}
+    public static DiscountType getType(int type){
+        for(DiscountType t : values()){
+            if(t.getValue()==type){
+                return t;
+            }
+        }
+        return null;
+    }
 }

--- a/app/src/main/java/com/example/discountcalc/DiscountType.java
+++ b/app/src/main/java/com/example/discountcalc/DiscountType.java
@@ -1,6 +1,7 @@
 package com.example.discountcalc;
 
 public enum DiscountType {
+    None,
     Custom,
     Const,
 }

--- a/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
@@ -25,7 +25,7 @@ import com.example.discountcalc.CalculationPack.DiscountCalc;
 import com.example.discountcalc.CustomAdapters.ResultLayoutAdapter;
 import com.example.discountcalc.DataBase.CustomConfigDataStoreSingleton;
 import com.example.discountcalc.DataBase.DataStoreHelper;
-import com.example.discountcalc.DiscountType;
+import com.example.discountcalc.Params.DiscountType;
 import com.example.discountcalc.Params.DiscountData;
 import com.example.discountcalc.R;
 import com.example.discountcalc.ViewModels.DiscountCalcViewModel;

--- a/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
@@ -26,6 +26,7 @@ import com.example.discountcalc.CalculationPack.DiscountCalc;
 import com.example.discountcalc.CustomAdapters.ResultLayoutAdapter;
 import com.example.discountcalc.DataBase.CustomConfigDataStoreSingleton;
 import com.example.discountcalc.DataBase.DataStoreHelper;
+import com.example.discountcalc.DiscountType;
 import com.example.discountcalc.Params.DiscountData;
 import com.example.discountcalc.R;
 import com.example.discountcalc.ViewModels.DiscountCalcViewModel;
@@ -38,8 +39,6 @@ import java.util.ArrayList;
 public class ResultListFragment extends Fragment {
     // データ保存に使うキー達
 
-    // 設定ファイル名保存キー("xxx".preferences_pb)
-    private static final String TAG_STORE_NAME = "custom_setting_data";
     //　割引率キー(x%)
     private static final String DISCOUNT_KEY = "discount_key";
 
@@ -82,6 +81,9 @@ public class ResultListFragment extends Fragment {
     // 結果表示数
     int viewCount;
 
+    // 計算タイプ
+    DiscountType discountType=DiscountType.None;
+
     // 余白の適用フラグ
     boolean[] paddingFlags;
 
@@ -102,10 +104,13 @@ public class ResultListFragment extends Fragment {
 
         //　表示数取得
         getViewCountData();
-        // 初回起動時の場合、データストアから値取得しないように(初期値-1になる為)
-        if(!createDataStoreInstance) {
-            // 保存データ取得
-            loadDataStore();
+            // 初回起動時の場合、データストアから値取得しないように(初期値-1になる為)
+
+        // 保存データ取得
+        loadDataStore();
+
+        if(discountType==DiscountType.None){
+            createDiscountPreferenceData();
         }
 
         // 計算
@@ -175,26 +180,15 @@ public class ResultListFragment extends Fragment {
     }
 
 
-    // DataStore取得
+    // DataStore取得(MainActivityで取得済み)
     private void getDataStoreInstance() {
         dataStoreSingleton = CustomConfigDataStoreSingleton.getInstance();
-        // データストアのSingletonが存在してなければ、新たにデータストアを作成
-        if (dataStoreSingleton.getDatastore() == null) {
-            datastoreRX = new RxPreferenceDataStoreBuilder(view.getContext(), TAG_STORE_NAME).build();
-            createDiscountPreferenceData();
-            createDataStoreInstance=true;
-        } else {
-            // データストア取得
-            datastoreRX = dataStoreSingleton.getDatastore();
-        }
-        // Singletonのデータストアにセット
-        dataStoreSingleton.setDataStore(datastoreRX);
-
     }
 
     // DataStoreのヘルパー取得
     private void dataStoreHelperInitialize(RxDataStore<Preferences> dataStore) {
         if (dataStoreHelper == null)
+            // 子フラグメントとして使用しているので親フラグメントのFragmentを引数に
             dataStoreHelper = new DataStoreHelper(this.getParentFragment(), dataStore);
     }
 

--- a/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
@@ -6,7 +6,6 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.datastore.preferences.core.Preferences;
-import androidx.datastore.preferences.rxjava3.RxPreferenceDataStoreBuilder;
 import androidx.datastore.rxjava3.RxDataStore;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
@@ -202,10 +201,12 @@ public class ResultListFragment extends Fragment {
                 Log.e("viewCount_put", discountKey + ":put_error");
                 return false;
             }
-            if(!dataStoreHelper.putIntegerValue(CONFIG_TYPE,discountType.getValue())){
-                Log.e("configType_put",discountType.toString());
-                return false;
-            }
+        }
+        if (!dataStoreHelper.putIntegerValue(CONFIG_TYPE, discountType.getValue())) {
+            Log.e("configType_put", discountType.toString());
+            return false;
+        } else {
+            Log.i("configType_put", discountType.toString());
         }
         return true;
     }
@@ -261,9 +262,10 @@ public class ResultListFragment extends Fragment {
         if (discountPers == null) {
             discountPers = new ArrayList<>();
         }
-        for(int i=0;i<discountData.length;i++){
-            discountPers.add(i,discountData[i]);
+        for (int i = 0; i < discountData.length; i++) {
+            discountPers.set(i, discountData[i]);
         }
+        discountType=DiscountType.Const;
     }
 
     private void setClickListener(View view) {

--- a/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
@@ -46,6 +46,8 @@ public class ResultListFragment extends Fragment {
     private static final String CONFIG_ENUM_KEY = "config_enum_key";
     // 表示数保存キー
     private static final String VIEWCOUNT = "view_count";
+    // 設定の種類
+    private static final String CONFIG_TYPE="config_type";
 
     // デフォルトの表示数
     private final int DEFAULT_VIEWCOUNT = 10;
@@ -157,7 +159,7 @@ public class ResultListFragment extends Fragment {
         int count = dataStoreHelper.getIntValue(viewcountKey);
 
         // データが存在しない場合デフォルト値をviewCountとし、その値も保存する
-        if (count == -1) {
+        if (count <= -1) {
             viewCount = DEFAULT_VIEWCOUNT;
             if(!dataStoreHelper.putIntegerValue(viewcountKey, viewCount)){
                 Log.e("viewcount_put",viewcountKey+":put_error");
@@ -193,13 +195,19 @@ public class ResultListFragment extends Fragment {
     }
 
     // DataStoreに割引データの設定を保存
-    private void saveDataStore() {
+    private boolean saveDataStore() {
         for(int i=0;i<viewCount;i++){
             final String discountKey=DISCOUNT_KEY+i;
             if(!dataStoreHelper.putIntegerValue(discountKey, discountPers.get(i))){
-                Log.e("viewcount_put",discountKey+":put_error");
-            };
+                Log.e("viewCount_put",discountKey+":put_error");
+                return false;
+            }
+            if(!dataStoreHelper.putIntegerValue(CONFIG_TYPE,discountType.getValue())){
+                Log.e("configType_put",discountType.toString());
+                return false;
+            }
         }
+        return true;
     }
 
     // DataStoreから割引データの設定取得
@@ -212,6 +220,8 @@ public class ResultListFragment extends Fragment {
             discountPers.add(i,dataStoreHelper.getIntValue(DISCOUNT_KEY + i));
             configEnums.add(i,dataStoreHelper.getIntValue(CONFIG_ENUM_KEY+i));
         }
+        int type=dataStoreHelper.getIntValue(CONFIG_TYPE);
+        discountType=;
     }
 
     // 計算処理

--- a/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
@@ -18,7 +18,6 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.InputMethodManager;
 
 import com.example.discountcalc.CalculationPack.ConvertDisplayUnitsHelper;
 import com.example.discountcalc.CalculationPack.DiscountCalc;
@@ -40,7 +39,6 @@ public class ResultListFragment extends Fragment {
 
     //　割引率キー(x%)
     private static final String DISCOUNT_KEY = "discount_key";
-
     // 必要かわからん
     private static final String CONFIG_ENUM_KEY = "config_enum_key";
     // 表示数保存キー
@@ -55,16 +53,13 @@ public class ResultListFragment extends Fragment {
     private int price=0;
     private View view;
 
-    private boolean createDataStoreInstance = false;
+    SharedPreferences preferences;
 
     private RecyclerView recyclerView;
     private ResultLayoutAdapter resultLayoutAdapter;
-    InputMethodManager inputMethodManager;
 
     DiscountCalcViewModel discountCalcViewModel;
 
-    // データストア
-    RxDataStore<Preferences> datastoreRX;
     // データストアのインスタンス取得用
     CustomConfigDataStoreSingleton dataStoreSingleton;
 
@@ -83,7 +78,7 @@ public class ResultListFragment extends Fragment {
     int viewCount;
 
     // 計算タイプ
-    DiscountType discountType = DiscountType.None;
+    DiscountType discountType;
 
     // 余白の適用フラグ
     boolean[] paddingFlags;
@@ -224,9 +219,17 @@ public class ResultListFragment extends Fragment {
             discountPers.add(i, dataStoreHelper.getIntValue(DISCOUNT_KEY + i));
             configEnums.add(i, dataStoreHelper.getIntValue(CONFIG_ENUM_KEY + i));
         }
+        getPreferences();
+    }
+
+    // デフォルトの割引率設定を指定
+    private void getPreferences() {
         // Preferences.xmlで保存された設定データを呼び出し、discountTypeにセット
-        SharedPreferences preferences=PreferenceManager.getDefaultSharedPreferences(this.requireContext());
-        String settingType=preferences.getString("usingSetting","none");
+        preferences=PreferenceManager.getDefaultSharedPreferences(this.requireContext());
+
+        String useKey=getString(R.string.using_setting);
+        // SharedPreferencesに保存された設定キー取得しセット。存在しない場合はNone
+        String settingType=preferences.getString(useKey,DiscountType.None.name());
         discountType = DiscountType.valueOf(settingType);
     }
 
@@ -272,16 +275,12 @@ public class ResultListFragment extends Fragment {
         for (int i = 0; i < discountData.length; i++) {
             discountPers.add(i, discountData[i]);
         }
+        // 使用する割引率設定をプリセットに指定して保存しておく。
         discountType=DiscountType.Preset;
-    }
 
-    private void setClickListener(View view) {
-        view.setOnClickListener(v -> {
-            // キーボードを隠す
-            view.setOnClickListener(c -> {
-                inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
-            });
-        });
+        // 使用する割引率設定を更新しておく。
+        String saveKey=getString(R.string.using_setting);
+        preferences.edit().putString(saveKey,discountType.toString()).apply();
     }
 
 }

--- a/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
@@ -195,6 +195,9 @@ public class ResultListFragment extends Fragment {
 
     // DataStoreに割引データの設定を保存
     private boolean saveDataStore() {
+        if(PreferenceManager.getDefaultSharedPreferences(requireContext()).getBoolean("isSavePreferences",false)){
+            return false;
+        }
         for (int i = 0; i < viewCount; i++) {
             final String discountKey = DISCOUNT_KEY + i;
             if (!dataStoreHelper.putIntegerValue(discountKey, discountPers.get(i))) {
@@ -221,8 +224,10 @@ public class ResultListFragment extends Fragment {
             discountPers.add(i, dataStoreHelper.getIntValue(DISCOUNT_KEY + i));
             configEnums.add(i, dataStoreHelper.getIntValue(CONFIG_ENUM_KEY + i));
         }
-        int type = dataStoreHelper.getIntValue(CONFIG_TYPE);
-        discountType = DiscountType.getType(type);
+        // Preferences.xmlで保存された設定データを呼び出し、discountTypeにセット
+        SharedPreferences preferences=PreferenceManager.getDefaultSharedPreferences(this.requireContext());
+        String settingType=preferences.getString("usingSetting","none");
+        discountType = DiscountType.valueOf(settingType);
     }
 
     // 計算処理
@@ -245,14 +250,16 @@ public class ResultListFragment extends Fragment {
     public void onPause() {
         super.onPause();
         // 一時中断で保存しておく
-        saveDataStore();
+        boolean isSave=saveDataStore();
+        Log.i("settingSave",String.valueOf(isSave));
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
         // Fragmentが削除された際に保存しておく
-        saveDataStore();
+        boolean isSave=saveDataStore();
+        Log.i("settingSave",String.valueOf(isSave));
     }
 
     // あらかじめ用意された割引率取得し、一覧データに使用する割引率を設定する。
@@ -263,9 +270,9 @@ public class ResultListFragment extends Fragment {
             discountPers = new ArrayList<>();
         }
         for (int i = 0; i < discountData.length; i++) {
-            discountPers.set(i, discountData[i]);
+            discountPers.add(i, discountData[i]);
         }
-        discountType=DiscountType.Const;
+        discountType=DiscountType.Preset;
     }
 
     private void setClickListener(View view) {

--- a/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/Fragments/ResultListFragment.java
@@ -47,16 +47,16 @@ public class ResultListFragment extends Fragment {
     // 表示数保存キー
     private static final String VIEWCOUNT = "view_count";
     // 設定の種類
-    private static final String CONFIG_TYPE="config_type";
+    private static final String CONFIG_TYPE = "config_type";
 
     // デフォルトの表示数
     private final int DEFAULT_VIEWCOUNT = 10;
 
     // 価格
-    private int price;
+    private int price=0;
     private View view;
 
-    private boolean createDataStoreInstance=false;
+    private boolean createDataStoreInstance = false;
 
     private RecyclerView recyclerView;
     private ResultLayoutAdapter resultLayoutAdapter;
@@ -84,7 +84,7 @@ public class ResultListFragment extends Fragment {
     int viewCount;
 
     // 計算タイプ
-    DiscountType discountType=DiscountType.None;
+    DiscountType discountType = DiscountType.None;
 
     // 余白の適用フラグ
     boolean[] paddingFlags;
@@ -94,8 +94,8 @@ public class ResultListFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         // Get the ViewModel.
-        Log.i("ResultListFragment","Called ViewModelProvider.get");
-        discountCalcViewModel=new ViewModelProvider(requireActivity()).get(DiscountCalcViewModel.class);
+        Log.i("ResultListFragment", "Called ViewModelProvider.get");
+        discountCalcViewModel = new ViewModelProvider(requireActivity()).get(DiscountCalcViewModel.class);
 
         LivedataInit();
 
@@ -106,23 +106,23 @@ public class ResultListFragment extends Fragment {
 
         //　表示数取得
         getViewCountData();
-            // 初回起動時の場合、データストアから値取得しないように(初期値-1になる為)
+        // 初回起動時の場合、データストアから値取得しないように(初期値-1になる為)
 
         // 保存データ取得
         loadDataStore();
 
-        if(discountType==DiscountType.None){
+        if (discountType == DiscountType.None) {
             createDiscountPreferenceData();
         }
 
         // 計算
         calcDiscounts();
 
-        paddingFlags=new boolean[4];
-        paddingFlags[2]=true;
+        paddingFlags = new boolean[4];
+        paddingFlags[2] = true;
 
         recyclerView = resultPriceListBinding.resultPriceList;
-        resultLayoutAdapter= new ResultLayoutAdapter(configDataList, ConvertDisplayUnitsHelper.dpToPx(30,requireContext()),paddingFlags);
+        resultLayoutAdapter = new ResultLayoutAdapter(configDataList, ConvertDisplayUnitsHelper.dpToPx(30, requireContext()), paddingFlags);
         // 縦方向のLayoutManagerを作成
         LinearLayoutManager llm = new LinearLayoutManager(resultPriceListBinding.getRoot().getContext());
         recyclerView.setHasFixedSize(true);
@@ -134,12 +134,12 @@ public class ResultListFragment extends Fragment {
     //入力価格データ購読設定
     private void LivedataInit() {
         // LiveData設定
-        final Observer<Integer> priceObserver= integer -> {
-            price=integer;
+        final Observer<Integer> priceObserver = integer -> {
+            price = integer;
             calcDiscounts();
             resultLayoutAdapter.updateItem(configDataList);
         };
-        discountCalcViewModel.getPrice().observe(getViewLifecycleOwner(),priceObserver);
+        discountCalcViewModel.getPrice().observe(getViewLifecycleOwner(), priceObserver);
     }
 
     @Override
@@ -155,29 +155,29 @@ public class ResultListFragment extends Fragment {
 
     // 表示数取得
     private void getViewCountData() {
-        final String viewcountKey=VIEWCOUNT;
+        final String viewcountKey = VIEWCOUNT;
         int count = dataStoreHelper.getIntValue(viewcountKey);
 
         // データが存在しない場合デフォルト値をviewCountとし、その値も保存する
         if (count <= -1) {
             viewCount = DEFAULT_VIEWCOUNT;
-            if(!dataStoreHelper.putIntegerValue(viewcountKey, viewCount)){
-                Log.e("viewcount_put",viewcountKey+":put_error");
+            if (!dataStoreHelper.putIntegerValue(viewcountKey, viewCount)) {
+                Log.e("viewcount_put", viewcountKey + ":put_error");
             }
         } else {
             viewCount = count;
             Log.i("viewCount", Integer.toString(count));
 
             //
-            SharedPreferences sharedPreferences= PreferenceManager.getDefaultSharedPreferences(requireContext());
-            viewCount=sharedPreferences.getInt("viewCount",-1);
-            Log.i("viewCount", "Result-sharedPreferences:"+count);
+            SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
+            viewCount = sharedPreferences.getInt("viewCount", -1);
+            Log.i("viewCount", "Result-sharedPreferences:" + count);
         }
 
         // リスト初期化
         configDataList = new ArrayList<>();
-        for(int i=0;i<viewCount;i++){
-            configDataList.add(i,new DiscountData());
+        for (int i = 0; i < viewCount; i++) {
+            configDataList.add(i, new DiscountData());
         }
     }
 
@@ -196,10 +196,10 @@ public class ResultListFragment extends Fragment {
 
     // DataStoreに割引データの設定を保存
     private boolean saveDataStore() {
-        for(int i=0;i<viewCount;i++){
-            final String discountKey=DISCOUNT_KEY+i;
-            if(!dataStoreHelper.putIntegerValue(discountKey, discountPers.get(i))){
-                Log.e("viewCount_put",discountKey+":put_error");
+        for (int i = 0; i < viewCount; i++) {
+            final String discountKey = DISCOUNT_KEY + i;
+            if (!dataStoreHelper.putIntegerValue(discountKey, discountPers.get(i))) {
+                Log.e("viewCount_put", discountKey + ":put_error");
                 return false;
             }
             if(!dataStoreHelper.putIntegerValue(CONFIG_TYPE,discountType.getValue())){
@@ -212,20 +212,20 @@ public class ResultListFragment extends Fragment {
 
     // DataStoreから割引データの設定取得
     private void loadDataStore() {
-        discountPers=new ArrayList<>();
-        configEnums=new ArrayList<>();
+        discountPers = new ArrayList<>();
+        configEnums = new ArrayList<>();
 
         for (int i = 0; i < viewCount; i++) {
             //ロード処理
-            discountPers.add(i,dataStoreHelper.getIntValue(DISCOUNT_KEY + i));
-            configEnums.add(i,dataStoreHelper.getIntValue(CONFIG_ENUM_KEY+i));
+            discountPers.add(i, dataStoreHelper.getIntValue(DISCOUNT_KEY + i));
+            configEnums.add(i, dataStoreHelper.getIntValue(CONFIG_ENUM_KEY + i));
         }
-        int type=dataStoreHelper.getIntValue(CONFIG_TYPE);
-        discountType=;
+        int type = dataStoreHelper.getIntValue(CONFIG_TYPE);
+        discountType = DiscountType.getType(type);
     }
 
     // 計算処理
-    private void calcDiscounts(){
+    private void calcDiscounts() {
         for (int i = 0; i < viewCount; i++) {
             // 割引率取得
             int discountPer = discountPers.get(i);
@@ -235,8 +235,8 @@ public class ResultListFragment extends Fragment {
             int afterPrice = price - discountPrice;
             //int enumKey = configEnums.get(i);
 
-            DiscountData data=new DiscountData(discountPer,discountPrice,afterPrice,0);
-            configDataList.set(i,data);
+            DiscountData data = new DiscountData(discountPer, discountPrice, afterPrice, 0);
+            configDataList.set(i, data);
         }
     }
 
@@ -255,10 +255,10 @@ public class ResultListFragment extends Fragment {
     }
 
     // あらかじめ用意された割引率取得し、一覧データに使用する割引率を設定する。
-    private void createDiscountPreferenceData(){
+    private void createDiscountPreferenceData() {
         // あらかじめ用意された割引率を取得
-        int[] discountData=getResources().getIntArray(R.array.PresetDiscounts);
-        if(discountPers==null) {
+        int[] discountData = getResources().getIntArray(R.array.PresetDiscounts);
+        if (discountPers == null) {
             discountPers = new ArrayList<>();
         }
         for(int i=0;i<discountData.length;i++){

--- a/app/src/main/java/com/example/discountcalc/Params/DiscountType.java
+++ b/app/src/main/java/com/example/discountcalc/Params/DiscountType.java
@@ -1,4 +1,4 @@
-package com.example.discountcalc;
+package com.example.discountcalc.Params;
 
 public enum DiscountType {
     None(-1),

--- a/app/src/main/java/com/example/discountcalc/Params/DiscountType.java
+++ b/app/src/main/java/com/example/discountcalc/Params/DiscountType.java
@@ -2,9 +2,8 @@ package com.example.discountcalc.Params;
 
 public enum DiscountType {
     None(-1),
-    Custom(0),
-    Const(1);
-
+    Preset(0),
+    Custom(1);
     private final int value;
     DiscountType(int value){
         this.value=value;

--- a/app/src/main/res/values/keynames.xml
+++ b/app/src/main/res/values/keynames.xml
@@ -1,0 +1,6 @@
+<resources>
+
+    <string name="using_setting">usingSetting</string>
+    <string name="is_save_parameters">isSaveParameters</string>
+    <string name="viewcount">viewCount</string>
+</resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -3,15 +3,16 @@
 
     <PreferenceCategory app:title="@string/messages_header">
         <ListPreference
-            app:key="using_setting"
-            app:title="使用する設定データ"
-            app:summary="カスタム設定・プリセット設定を切り替えます"
+            app:defaultValue="1"
             app:entries="@array/settings_params"
             app:entryValues="@array/settings_params"
-            app:useSimpleSummaryProvider="true"
-            />
+            app:key="usingSetting"
+            app:summary="カスタム設定・プリセット設定を切り替えます"
+            app:title="使用する設定データ"
+            app:useSimpleSummaryProvider="true" />
 
         <CheckBoxPreference
+            app:key="isSaveParameters"
             app:title="パラメータの保存"
             app:defaultValue="true"
             />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -6,20 +6,20 @@
             app:defaultValue="1"
             app:entries="@array/settings_params"
             app:entryValues="@array/settings_params"
-            app:key="usingSetting"
+            app:key="@string/using_setting"
             app:summary="カスタム設定・プリセット設定を切り替えます"
             app:title="使用する設定データ"
             app:useSimpleSummaryProvider="true" />
 
         <CheckBoxPreference
-            app:key="isSaveParameters"
+            app:key="@string/is_save_parameters"
             app:title="パラメータの保存"
             app:defaultValue="true"
             />
 
         <SeekBarPreference
             app:title="表示数"
-            app:key="viewCount"
+            app:key="@string/viewcount"
             android:max="10"
             app:min="1"
             app:defaultValue="10"


### PR DESCRIPTION
**### データストアの取得をアクティビティで行うように変更。**

・一部誤っていた処理を修正
 -discountPersリストがaddで無駄な空要素が生成されていた物を修正
・確認用のログ追加。
・DiscountTypeのenumにgetTypeを追加
・DiscountTypeのディレクトリを変更
・Preferences.xmlのkeyの名前に統一性を持たせる
・DataStoreに保持していた使用する設定データを、androidStudioのPreferenceManagerから取得するように変更。(仮作成)
・ハードコードによる取得エラーを無くすため。
 -ResultListFragmentの使われていない変数、処理を削除。
 -sharedPreferencesから設定データ取得する処理を修正。
・データがないときにPresetデータを取得した際、使用する割引率設定を保存する処理を追加。