### PR TITLE
Fix preferencedao

### DIFF
--- a/app/src/main/java/com/example/discountcalc/DAO/PreferenceParamDAO.java
+++ b/app/src/main/java/com/example/discountcalc/DAO/PreferenceParamDAO.java
@@ -1,5 +1,6 @@
 package com.example.discountcalc.DAO;
 
+import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
 import androidx.room.Delete;
 import androidx.room.Insert;
@@ -39,13 +40,13 @@ public interface PreferenceParamDAO {
     int deleteAll();
 
     @Query("SELECT * FROM custom_preference_table")
-    List<PreferenceParam> getAll();
+    LiveData<List<PreferenceParam>> getAll();
 
     @Query("SELECT uid,save_name,per FROM custom_preference_table WHERE save_name LIKE :saveName")
-    List<PreferenceParam> getSave(String saveName);
+    LiveData<List<PreferenceParam>> getSave(String saveName);
 
     @Query("SELECT DISTINCT save_name from custom_preference_table")
-    List<String> getSaveNameColumnsList();
+    LiveData<List<String>> getSaveNameColumnsList();
 
     @RawQuery
     List<SQLiteTableInfo> getTableInfoList(SupportSQLiteQuery query);

--- a/app/src/main/java/com/example/discountcalc/dataBase/PreferenceParamRepository.java
+++ b/app/src/main/java/com/example/discountcalc/dataBase/PreferenceParamRepository.java
@@ -3,6 +3,8 @@ package com.example.discountcalc.dataBase;
 import android.app.Application;
 import android.util.Log;
 
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 import androidx.sqlite.db.SimpleSQLiteQuery;
 
 import com.example.discountcalc.DAO.PreferenceParamDAO;
@@ -12,17 +14,16 @@ import com.example.discountcalc.params.SQLiteTableInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 // TODO:Singletonで実装したほうがいい気はする。
 public class PreferenceParamRepository {
-    private PreferenceParamDAO preferenceParamDAO;
-    private List<PreferenceParam> preferenceParamList;
+    private final PreferenceParamDAO preferenceParamDAO;
+    private final LiveData<List<PreferenceParam>> preferenceParamList;
 
     private List<SQLiteTableInfo> sqLiteTableInfoList;
-
-    private List<String> saveNameList;
-
-    private int result;
+    int result;
 
     // WordRepositoryをユニットテストするには、Application依存関係を削除する必要があることに注意
 
@@ -31,19 +32,16 @@ public class PreferenceParamRepository {
     public PreferenceParamRepository(Application application){
         AppDataBase db = AppDataBase.getDatabase(application);
         preferenceParamDAO=db.preferenceParamDAO();
-        preferenceParamList=new ArrayList<>();
+        preferenceParamList= preferenceParamDAO.getAll();
         sqLiteTableInfoList =new ArrayList<>();
-        saveNameList=new ArrayList<>();
         Log.i("database", Objects.requireNonNull(db.getOpenHelper().getDatabaseName()));
     }
 
-    // Roomは全てのクエリを別スレッドで実行する。
-    public List<PreferenceParam> getAll(){
-        AppDataBase.databaseWriteExecutor.execute(()->{
-            preferenceParamList = preferenceParamDAO.getAll();
-        });
+    public LiveData<List<PreferenceParam>> PreferenceParamList(){
         return preferenceParamList;
     }
+
+    // Roomは全てのクエリを別スレッドで実行する。
 
     // これを非UIスレッド上で呼び出さないと、アプリが例外をスローする。
     // Roomは、メイン・スレッドで長時間実行する操作を行わず、UIをブロックしないようにする。
@@ -60,7 +58,7 @@ public class PreferenceParamRepository {
                 preferenceParamDAO.upsert(param);
                 //Log.i("upsert","saveName:"+param.saveName()+" per:"+param.per());
             }catch(Exception e){
-                Log.e("database",e.getMessage());
+                Log.e("database", Objects.requireNonNull(e.getMessage()));
             }
         });
     }
@@ -70,7 +68,7 @@ public class PreferenceParamRepository {
             try{
                 preferenceParamDAO.upsertAll(params);
             }catch(Exception e){
-                Log.e("database",e.getMessage());
+                Log.e("database", Objects.requireNonNull(e.getMessage()));
             }
         });
         Log.i("database","do_upsert");
@@ -82,43 +80,26 @@ public class PreferenceParamRepository {
         });
     }
 
-    public int delete(PreferenceParam param){
+    public void delete(PreferenceParam param){
         AppDataBase.databaseWriteExecutor.execute(()->{
-        result= preferenceParamDAO.delete(param);
+         preferenceParamDAO.delete(param);
         });
-        return result;
     }
 
-    public int deleteForSaveName(String saveName){
+    public void deleteForSaveName(String saveName){
         AppDataBase.databaseWriteExecutor.execute(()->{
             result= preferenceParamDAO.deleteForSaveName(saveName);
         });
-        return result;
     }
 
-    public int deleteAll(){
+    public void deleteAll(){
         AppDataBase.databaseWriteExecutor.execute(()->{
            result= preferenceParamDAO.deleteAll();
         });
-        return result;
-    }
-
-    public List<PreferenceParam> getSave(String getName){
-        AppDataBase.databaseWriteExecutor.execute(()->{
-            preferenceParamList=preferenceParamDAO.getSave(getName);
-        });
-        return preferenceParamList;
-    }
-
-    public List<String> getSaveNameColumnsList(){
-        AppDataBase.databaseWriteExecutor.execute(()->{
-            saveNameList= preferenceParamDAO.getSaveNameColumnsList();
-        });
-        return saveNameList;
     }
 
     public List<String> getTableInfoList(){
-        AppDataBase.databaseWriteExecutor.execute(()->{
+        AppDataBase.databaseWriteExecutor.submit(()->{
             SimpleSQLiteQuery query=new SimpleSQLiteQuery("PRAGMA table_info(custom_preference_table)");
             sqLiteTableInfoList =preferenceParamDAO.getTableInfoList(query);
         });

--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -110,32 +110,24 @@ public class CustomDiscountPreferenceFragment extends Fragment {
 
         // ViewModel内のリポジトリLiveDataの購読。
         customPreferenceViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams -> {
-            if(customPreferenceViewModel.PreferenceParamList().getValue()==null){
-                // PreferenceListが存在していないときにDBの情報をセットさせる。
-                // 初期化の代わり。
-                customPreferenceViewModel.commitPreferenceParamList();
-                //updateUI();
-            }
+            updateUI();
             setOnClickListeners();
         });
-        // ViewModel内の設定保存データの追跡。
-        customPreferenceViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams -> {
-            updateUI();
-        });
-
     }
 
     private void updateUI() {
         Log.i("updateUI","updateUI");
-        if(customPreferenceViewModel.PreferenceParamList().getValue()==null)return;
 
-        List<CustomPreferenceData> dataList=new ArrayList<>(0);
+        List<CustomPreferenceData> dataList=new ArrayList<>();
         // 新しくデータリストを作成し、それをアダプターとTextViewにセットする。
-        for (var d:customPreferenceViewModel.PreferenceParamList().getValue()) {
-            dataList.add(new CustomPreferenceData(d.uid(),d.per(),d.saveName()));
+        List<PreferenceParam> params=customPreferenceViewModel.PreferenceParamList().getValue();
+        for (int i=0;i<params.size();i++){
+            dataList.add(new CustomPreferenceData(i+1,params.get(i).per(),params.get(i).saveName()));
         }
-        elementNumberViewText.setText(""+customPreferenceViewModel.listSize());
         customPreferenceListAdapter.submitList(new ArrayList<>(Objects.requireNonNull(dataList)));
+        elementNumberViewText.setText(""+customPreferenceListAdapter.getItemCount());
+
+        saveDataListViewAdapter.submitList(new ArrayList<>(customPreferenceViewModel.getSaveNameList()));
     }
 
     public void setOnClickListeners(){
@@ -187,7 +179,6 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         customPreferenceListAdapter=new CustomPreferenceListAdapter();
 
         LinearLayoutManager llm=new LinearLayoutManager(view.getContext());
-        customPreferenceListView.setHasFixedSize(true);
         customPreferenceListView.setLayoutManager(llm);
         customPreferenceListView.setAdapter(customPreferenceListAdapter);
 
@@ -195,7 +186,6 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         saveDataListView=customDiscountPreferenceFragmentBinding.saveDataList;
         saveDataListViewAdapter=new SaveDataListViewAdapter();
         LinearLayoutManager llm2=new LinearLayoutManager(view.getContext());
-        saveDataListView.setHasFixedSize(true);
         saveDataListView.setLayoutManager(llm2);
         saveDataListView.setAdapter(saveDataListViewAdapter);
     }
@@ -255,7 +245,6 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         // 表示数が10未満の時、リサイクルビューのサイズ変更を固定にする。
         customPreferenceListView.setHasFixedSize(customPreferenceViewModel.listSize() >= 10);
 
-        updateUI();
     }
 
     private boolean removePreferenceDataElement(int removeElementNumber){

--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -23,12 +23,16 @@ import com.example.discountcalc.customAdapters.SaveDataListViewAdapter;
 import com.example.discountcalc.dataBase.AppDataBase;
 import com.example.discountcalc.databinding.CustomDiscountPreferenceFragmentBinding;
 import com.example.discountcalc.R;
+import com.example.discountcalc.params.CustomPreferenceData;
+import com.example.discountcalc.params.PreferenceParam;
 import com.example.discountcalc.viewModels.SaveTitleViewOneLineParamViewModel;
 import com.example.discountcalc.viewModels.CustomPreferenceListViewModel;
 import com.example.discountcalc.viewModels.CustomPreferenceListViewModelFactory;
 import com.example.discountcalc.viewModels.SaveTitleViewOneLineParamViewModelFactory;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 public class CustomDiscountPreferenceFragment extends Fragment {
 
@@ -66,7 +70,6 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         bindingElements();
         viewModelInitialize();
         recyclerViewInitialize();
-        setOnClickListeners();
     }
 
 
@@ -104,12 +107,35 @@ public class CustomDiscountPreferenceFragment extends Fragment {
                 .get(CustomPreferenceListViewModel.class);
         saveTitleViewOneLineParamViewModel=new ViewModelProvider(this,new SaveTitleViewOneLineParamViewModelFactory(requireActivity().getApplication()))
                 .get(SaveTitleViewOneLineParamViewModel.class);
-        elementNumberViewText.setText(""+customPreferenceViewModel.listSize());
+
+        // ViewModel内のリポジトリLiveDataの購読。
+        customPreferenceViewModel.RepoPreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams -> {
+            if(customPreferenceViewModel.PreferenceParamList().getValue()==null){
+                // PreferenceListが存在していないときにDBの情報をセットさせる。
+                // 初期化の代わり。
+                customPreferenceViewModel.commitPreferenceParamList();
+                //updateUI();
+            }
+            setOnClickListeners();
+        });
+        // ViewModel内の設定保存データの追跡。
+        customPreferenceViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams -> {
+            updateUI();
+        });
+
     }
 
     private void updateUI() {
         Log.i("updateUI","updateUI");
-        customPreferenceListAdapter.submitList(new ArrayList<>(customPreferenceViewModel.CustomPreferenceList().getValue()));
+        if(customPreferenceViewModel.PreferenceParamList().getValue()==null)return;
+
+        List<CustomPreferenceData> dataList=new ArrayList<>(0);
+        // 新しくデータリストを作成し、それをアダプターとTextViewにセットする。
+        for (var d:customPreferenceViewModel.PreferenceParamList().getValue()) {
+            dataList.add(new CustomPreferenceData(d.uid(),d.per(),d.saveName()));
+        }
+        elementNumberViewText.setText(""+customPreferenceViewModel.listSize());
+        customPreferenceListAdapter.submitList(new ArrayList<>(Objects.requireNonNull(dataList)));
     }
 
     public void setOnClickListeners(){
@@ -143,7 +169,7 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         saveButton.setOnClickListener(b->{
             b.setEnabled(false);
             saveDataStore();
-            saveDataListViewAdapter.submitList(new ArrayList<>(customPreferenceViewModel.SaveNameList()));
+            saveDataListViewAdapter.submitList(new ArrayList<>(customPreferenceViewModel.getSaveNameList()));
             // 1秒後にボタン再使用可能に
             Handler handler=new Handler();
             handler.postDelayed(() ->{
@@ -226,14 +252,9 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         //customPreferenceViewModel.addPreferenceData(newData);
 
         customPreferenceViewModel.addDefaultPreferenceData();
-        // テキスト更新
-        int listSize= customPreferenceViewModel.listSize();
-        //elementNumberViewText.setText("viewmodel:"+listSize+"adapter"+customPreferenceListAdapter.getItemCount());
-        //customPreferenceListAdapter.notifyItemInserted(listSize-1);
         // 表示数が10未満の時、リサイクルビューのサイズ変更を固定にする。
-        customPreferenceListView.setHasFixedSize(listSize >= 10);
+        customPreferenceListView.setHasFixedSize(customPreferenceViewModel.listSize() >= 10);
 
-        elementNumberViewText.setText(listSize+"");
         updateUI();
     }
 

--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -109,7 +109,7 @@ public class CustomDiscountPreferenceFragment extends Fragment {
                 .get(SaveTitleViewOneLineParamViewModel.class);
 
         // ViewModel内のリポジトリLiveDataの購読。
-        customPreferenceViewModel.RepoPreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams -> {
+        customPreferenceViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams -> {
             if(customPreferenceViewModel.PreferenceParamList().getValue()==null){
                 // PreferenceListが存在していないときにDBの情報をセットさせる。
                 // 初期化の代わり。

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -75,28 +75,7 @@ public class ResultListFragment extends Fragment {
         Log.i("ResultListFragment", "Called ViewModelProvider.get");
         viewModelInitialize();
 
-        LivedataInit();
 
-        // 保存データ取得
-        loadSettingData();
-
-        if (discountType == DiscountType.None) {
-            createDiscountPreferenceData();
-        }
-
-        // 計算
-        calcDiscounts();
-
-        paddingFlags = new boolean[4];
-        paddingFlags[2] = true;
-
-        recyclerView = resultPriceListBinding.resultPriceList;
-        resultLayoutAdapter = new ResultLayoutAdapter(resultDataList, ConvertDisplayUnitsHelper.dpToPx(30, requireContext()), paddingFlags);
-        // 縦方向のLayoutManagerを作成
-        LinearLayoutManager llm = new LinearLayoutManager(resultPriceListBinding.getRoot().getContext());
-        recyclerView.setHasFixedSize(true);
-        recyclerView.setLayoutManager(llm);
-        recyclerView.setAdapter(resultLayoutAdapter);
 
     }
 
@@ -104,6 +83,33 @@ public class ResultListFragment extends Fragment {
         discountCalcViewModel = new ViewModelProvider(requireActivity()).get(DiscountCalcViewModel.class);
         customPreferenceListViewModel =new ViewModelProvider(this,new CustomPreferenceListViewModelFactory(requireActivity().getApplication()))
                 .get(CustomPreferenceListViewModel.class);
+
+        // ViewModelのリポジトリLiveDataを購読。
+        customPreferenceListViewModel.RepoPreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams->{
+            // 保存データ取得
+            loadSettingData();
+
+            if (discountType == DiscountType.None) {
+                createDiscountPreferenceData();
+            }
+
+            // 計算
+            calcDiscounts();
+
+            paddingFlags = new boolean[4];
+            paddingFlags[2] = true;
+
+            recyclerView = resultPriceListBinding.resultPriceList;
+            resultLayoutAdapter = new ResultLayoutAdapter(resultDataList, ConvertDisplayUnitsHelper.dpToPx(30, requireContext()), paddingFlags);
+            // 縦方向のLayoutManagerを作成
+            LinearLayoutManager llm = new LinearLayoutManager(resultPriceListBinding.getRoot().getContext());
+            recyclerView.setHasFixedSize(true);
+            recyclerView.setLayoutManager(llm);
+            recyclerView.setAdapter(resultLayoutAdapter);
+
+
+            LivedataInit();
+        });
     }
 
     //入力価格データ購読設定
@@ -138,15 +144,16 @@ public class ResultListFragment extends Fragment {
 
         // 割引率のリスト初期化
         discountPerList=new ArrayList<>();
+
         switch (discountType) {
             case None, Preset -> createDiscountPreferenceData();
             case Custom -> {
-                if(customPreferenceListViewModel.listSize()==0){
+                if(customPreferenceListViewModel.RepoPreferenceParamList().getValue().size()==0){
                     createDiscountPreferenceData();
                     break;
                 }
-                for (int i = 0; i < customPreferenceListViewModel.listSize(); i++) {
-                    discountPerList.add(i, customPreferenceListViewModel.getCustomPreferenceData(i).DiscountPer());
+                for (int i = 0; i < customPreferenceListViewModel.RepoPreferenceParamList().getValue().size(); i++) {
+                    discountPerList.add(i, customPreferenceListViewModel.RepoPreferenceParamList().getValue().get(i).per());
                 }
             }
         }
@@ -169,6 +176,8 @@ public class ResultListFragment extends Fragment {
     // 計算処理
     private void calcDiscounts() {
         resultDataList.clear();
+        // 表示数が利用する割引率のリストよりも大きければ、利用する割引率のリストに合わせる。OutOfBoundsの防止
+        if(viewCount>discountPerList.size())viewCount=discountPerList.size();
         for (int i = 0; i < viewCount; i++) {
             // 割引率取得
             int discountPer = discountPerList.get(i);

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -85,7 +85,7 @@ public class ResultListFragment extends Fragment {
                 .get(CustomPreferenceListViewModel.class);
 
         // ViewModelのリポジトリLiveDataを購読。
-        customPreferenceListViewModel.RepoPreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams->{
+        customPreferenceListViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams->{
             // 保存データ取得
             loadSettingData();
 
@@ -148,12 +148,12 @@ public class ResultListFragment extends Fragment {
         switch (discountType) {
             case None, Preset -> createDiscountPreferenceData();
             case Custom -> {
-                if(customPreferenceListViewModel.RepoPreferenceParamList().getValue().size()==0){
+                if(customPreferenceListViewModel.PreferenceParamList().getValue().size()==0){
                     createDiscountPreferenceData();
                     break;
                 }
-                for (int i = 0; i < customPreferenceListViewModel.RepoPreferenceParamList().getValue().size(); i++) {
-                    discountPerList.add(i, customPreferenceListViewModel.RepoPreferenceParamList().getValue().get(i).per());
+                for (int i = 0; i < customPreferenceListViewModel.PreferenceParamList().getValue().size(); i++) {
+                    discountPerList.add(i, customPreferenceListViewModel.PreferenceParamList().getValue().get(i).per());
                 }
             }
         }

--- a/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
+++ b/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
@@ -37,12 +37,19 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
         return preferenceParamList;
     }
 
-    public LiveData<List<CustomPreferenceData>> CustomPreferenceList(){
-        return preferenceDataList;
+    // リポジトリのデータをviewModelにセット
+    public void commitPreferenceParamList(){
+        List<PreferenceParam> currentList=new ArrayList<>(0);
+        List<PreferenceParam> repoParamList=repoPreferenceParamList.getValue();
+
+        for(int i=0;i<repoParamList.size();i++){
+            currentList.add(new PreferenceParam(i+1,repoParamList.get(i).saveName(),repoParamList.get(i).per()));
+        }
+        preferenceParamList.postValue(currentList);
     }
 
-    public List<String> SaveNameList(){
-        return SaveNameColumnsList();
+    public LiveData<List<PreferenceParam>> RepoPreferenceParamList(){
+        return repoPreferenceParamList;
     }
 
     public PreferenceParam getCustomPreferenceParam(int index){

--- a/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
+++ b/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
@@ -23,14 +23,15 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
     //private final MutableLiveData<List<CustomPreferenceData>> preferenceDataList;
     private final MutableLiveData<List<PreferenceParam>> preferenceParamList;
     // リポジトリのLiveData追跡用のフィールド
-    private final LiveData<List<PreferenceParam>> repoPreferenceParamList;
+//    private final LiveData<List<PreferenceParam>> repoPreferenceParamList;
 
 
     public CustomPreferenceListViewModel(Application application){
         super(application);
         dataRepository=new PreferenceParamRepository(application);
         preferenceParamList=new MutableLiveData<>();
-        repoPreferenceParamList= dataRepository.PreferenceParamList();
+        dataRepository.PreferenceParamList().observeForever(preferenceParamList::setValue);
+//        repoPreferenceParamList= dataRepository.PreferenceParamList();
     }
 
     public LiveData<List<PreferenceParam>> PreferenceParamList(){
@@ -39,18 +40,16 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
 
     // リポジトリのデータをviewModelにセット
     public void commitPreferenceParamList(){
+        if(preferenceParamList.getValue()==null)return;
         List<PreferenceParam> currentList=new ArrayList<>(0);
-        List<PreferenceParam> repoParamList=repoPreferenceParamList.getValue();
+        //List<PreferenceParam> repoParamList=repoPreferenceParamList.getValue();
 
-        for(int i=0;i<repoParamList.size();i++){
-            currentList.add(new PreferenceParam(i+1,repoParamList.get(i).saveName(),repoParamList.get(i).per()));
+        for(int i=0;i<preferenceParamList.getValue().size();i++){
+            currentList.add(new PreferenceParam(i+1,preferenceParamList.getValue().get(i).saveName(),preferenceParamList.getValue().get(i).per()));
         }
         preferenceParamList.postValue(currentList);
     }
 
-    public LiveData<List<PreferenceParam>> RepoPreferenceParamList(){
-        return repoPreferenceParamList;
-    }
 
     public PreferenceParam getCustomPreferenceParam(int index){
         return Objects.requireNonNull(preferenceParamList.getValue()).get(index);
@@ -61,14 +60,14 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
     }
 
     public void addPreferenceData(int per,String saveName){
-        if(preferenceParamList.getValue()==null) preferenceParamList.setValue(repoPreferenceParamList.getValue());
+//        if(preferenceParamList.getValue()==null) preferenceParamList.setValue(repoPreferenceParamList.getValue());
         List<PreferenceParam> currentList=new ArrayList<>(Objects.requireNonNull(preferenceParamList.getValue()));
         currentList.add(new PreferenceParam(listSize()+1,saveName,per));
         preferenceParamList.setValue(currentList);
     }
 
     public void addDefaultPreferenceData(){
-        if(preferenceParamList.getValue()==null) preferenceParamList.setValue(repoPreferenceParamList.getValue());
+//        if(preferenceParamList.getValue()==null) preferenceParamList.setValue(repoPreferenceParamList.getValue());
         List<PreferenceParam> currentList=new ArrayList<>(Objects.requireNonNull(preferenceParamList.getValue()));
         currentList.add(new PreferenceParam(listSize()+1,"",0));
         preferenceParamList.setValue(currentList);
@@ -142,7 +141,7 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
 
     // リポジトリのデータから保存名のリストを重複を取り除いて抽出
     public List<String> getSaveNameList(){
-        return Objects.requireNonNull(repoPreferenceParamList.getValue()).stream()
+        return preferenceParamList.getValue().stream()
                 .map(PreferenceParam::saveName)
                 .distinct()
                 .collect(Collectors.toList());

--- a/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
+++ b/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
@@ -2,15 +2,12 @@ package com.example.discountcalc.viewModels;
 
 import android.app.Application;
 import android.content.Context;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
-import com.example.discountcalc.DAO.PreferenceParamDAO;
-import com.example.discountcalc.dataBase.AppDataBase;
 import com.example.discountcalc.dataBase.PreferenceParamRepository;
 import com.example.discountcalc.params.CustomPreferenceData;
 import com.example.discountcalc.params.PreferenceParam;
@@ -18,21 +15,26 @@ import com.example.discountcalc.params.PreferenceParam;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class CustomPreferenceListViewModel extends AndroidViewModel {
 
     private PreferenceParamRepository dataRepository;
-    AppDataBase dataBase;
-    private final MutableLiveData<List<CustomPreferenceData>> preferenceDataList;
+    //private final MutableLiveData<List<CustomPreferenceData>> preferenceDataList;
+    private final MutableLiveData<List<PreferenceParam>> preferenceParamList;
+    // リポジトリのLiveData追跡用のフィールド
+    private final LiveData<List<PreferenceParam>> repoPreferenceParamList;
 
-    private List<PreferenceParam> allSaveDataList;
 
     public CustomPreferenceListViewModel(Application application){
         super(application);
         dataRepository=new PreferenceParamRepository(application);
-        preferenceDataList =new MutableLiveData<>(new ArrayList<>(0));
-        allSaveDataList=new ArrayList<>(0);
-        getAllDAO();
+        preferenceParamList=new MutableLiveData<>();
+        repoPreferenceParamList= dataRepository.PreferenceParamList();
+    }
+
+    public LiveData<List<PreferenceParam>> PreferenceParamList(){
+        return preferenceParamList;
     }
 
     public LiveData<List<CustomPreferenceData>> CustomPreferenceList(){
@@ -43,67 +45,60 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
         return SaveNameColumnsList();
     }
 
-    public CustomPreferenceData getCustomPreferenceData(int index){
-        return Objects.requireNonNull(preferenceDataList.getValue()).get(index);
+    public PreferenceParam getCustomPreferenceParam(int index){
+        return Objects.requireNonNull(preferenceParamList.getValue()).get(index);
     }
 
     public int listSize(){
-        return Objects.requireNonNull(preferenceDataList.getValue()).size();
+        return preferenceParamList.getValue().size();
     }
-
-    public void setPreferenceDataList(List<CustomPreferenceData> datas){
-        this.preferenceDataList.setValue(datas);
-    }
-
 
     public void addPreferenceData(int per,String saveName){
-        List<CustomPreferenceData> currentList=CustomPreferenceList().getValue();
-        CustomPreferenceData data=new CustomPreferenceData(listSize()+1,per,saveName);
-        currentList.add(data);
-        preferenceDataList.setValue(currentList);
-
+        if(preferenceParamList.getValue()==null) preferenceParamList.setValue(repoPreferenceParamList.getValue());
+        List<PreferenceParam> currentList=new ArrayList<>(Objects.requireNonNull(preferenceParamList.getValue()));
+        currentList.add(new PreferenceParam(listSize()+1,saveName,per));
+        preferenceParamList.setValue(currentList);
     }
 
     public void addDefaultPreferenceData(){
-        List<CustomPreferenceData> currentList=CustomPreferenceList().getValue();
-        CustomPreferenceData data=new CustomPreferenceData(listSize()+1,0,"");
-        currentList.add(data);
-        preferenceDataList.setValue(currentList);
-
+        if(preferenceParamList.getValue()==null) preferenceParamList.setValue(repoPreferenceParamList.getValue());
+        List<PreferenceParam> currentList=new ArrayList<>(Objects.requireNonNull(preferenceParamList.getValue()));
+        currentList.add(new PreferenceParam(listSize()+1,"",0));
+        preferenceParamList.setValue(currentList);
     }
 
-    public void updatePreferenceData(int index,CustomPreferenceData newData){
-        List<CustomPreferenceData> currentList=new ArrayList<>(Objects.requireNonNull(preferenceDataList.getValue()));
+    public void updatePreferenceData(int index,PreferenceParam newData){
+        List<PreferenceParam> currentList=new ArrayList<>(Objects.requireNonNull(preferenceParamList.getValue()));
         if(index>=0&&index<currentList.size()){
-            currentList.get(index).getDiscountNo().setValue(currentList.get(index).getDiscountNo().getValue());
-            currentList.get(index).getDiscountPer().setValue(currentList.get(index).getDiscountPer().getValue());
-            preferenceDataList.setValue(currentList);
+            currentList.get(index).uid();
+            currentList.get(index).per();
+            preferenceParamList.setValue(currentList);
         }
 
     }
 
     // 指定したインデックスのデータを更新
-    public void updatePreferenceDataAll(List<CustomPreferenceData> newData) {
+    public void updatePreferenceDataAll(List<PreferenceParam> newData) {
         if (newData != null) {
-            preferenceDataList.setValue(newData);
+            preferenceParamList.setValue(newData);
         }
     }
 
     public void removePreferenceData(int index){
-        if(0<index&&index<preferenceDataList.getValue().size()){
-            preferenceDataList.getValue().remove(index);
+        if(0<index&&index<preferenceParamList.getValue().size()){
+            preferenceParamList.getValue().remove(index);
         }
     }
 
     public void changeTextView(Context context, int index,int value){
-        Objects.requireNonNull(preferenceDataList.getValue()).get(index).setDiscountNo(value);
+        Objects.requireNonNull(preferenceParamList.getValue()).get(index).uid();
     }
 
     public boolean saveNewData(@NonNull String saveName){
-        if(preferenceDataList.getValue()!=null) {
+        if(preferenceParamList.getValue()!=null) {
             List<PreferenceParam> params=new ArrayList<>();
-            for (var data : preferenceDataList.getValue()) {
-                params.add(PreferenceParam.createPreferenceParam(saveName, data.DiscountPer()));
+            for (var data : preferenceParamList.getValue()) {
+                params.add(PreferenceParam.createPreferenceParam(saveName, data.uid()));
             }
             dataRepository.insert(params);
             return true;
@@ -112,10 +107,10 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
     }
 
     public boolean SaveUpdateData(@NonNull String saveName){
-        if(preferenceDataList.getValue()!=null){
+        if(preferenceParamList.getValue()!=null){
             List<PreferenceParam> params=new ArrayList<>();
-            for (var data : preferenceDataList.getValue()) {
-                params.add(PreferenceParam.createPreferenceParam(saveName, data.DiscountPer()));
+            for (var data : preferenceParamList.getValue()) {
+                params.add(PreferenceParam.createPreferenceParam(saveName, data.per()));
             }
             dataRepository.update(params);
             return true;
@@ -124,48 +119,26 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
     }
 
     public boolean updateDAO() {
-        if(preferenceDataList.getValue()!=null) {
+        if(preferenceParamList.getValue()!=null) {
             // データベース取得
-            PreferenceParamDAO preferenceParamDAO = dataBase.preferenceParamDAO();
             //TODO　保存処理を書く
 
-
-            Log.i("database", dataBase.preferenceParamDAO().getAll().stream().toString());
         return true;
         }
         return false;
     }
 
+    //　引数の名前が既に保存されていないか確認
     public boolean existingCheckDAO(String name){
-        List<PreferenceParam> params;
-        params= dataRepository.getSave(name);
-        for(PreferenceParam param:params){
-            if(param.saveName().equals(name))return true;
-        }
-        return false;
+        return getSaveNameList().stream().noneMatch(name::equals);
     }
 
-    public void getAllDAO(){
-        List<PreferenceParam> params;
-        params= dataRepository.getAll();
-        if(params!=null) {
-            Log.i("repository","connectSuccess");
-            Log.i("getAllDAO",params.size()+"");
-            allSaveDataList=params;
-            params.forEach(t->{
-                Log.i("repository",t.toString());
-            });
-        }else{
-            Log.i("repository","notConnect");
-        }
-    }
-
-    public void deleteAllDAO(){
-        dataRepository.deleteAll();
-    }
-
-    private List<String> SaveNameColumnsList(){
-        return dataRepository.getSaveNameColumnsList();
+    // リポジトリのデータから保存名のリストを重複を取り除いて抽出
+    public List<String> getSaveNameList(){
+        return Objects.requireNonNull(repoPreferenceParamList.getValue()).stream()
+                .map(PreferenceParam::saveName)
+                .distinct()
+                .collect(Collectors.toList());
     }
 
 }

--- a/app/src/main/java/com/example/discountcalc/viewModels/SaveTitleViewOneLineParamViewModel.java
+++ b/app/src/main/java/com/example/discountcalc/viewModels/SaveTitleViewOneLineParamViewModel.java
@@ -20,7 +20,6 @@ public class SaveTitleViewOneLineParamViewModel extends AndroidViewModel {
     }
 
     public void setLoadSaveTitleColumn(String loadSaveTitleColumn) {
-        repository.getSave(loadSaveTitleColumn);
         this.loadSaveTitleColumn.setValue(loadSaveTitleColumn);
     }
 }


### PR DESCRIPTION
【実装】
・CustomPreferenceListViewModel.java
-保存名のリスト取得を行なうgetSaveNameListメソッドを作成。
-commitPreferenceParamListメソッドを追加。リポジトリから取得したLiveDataから値を抜き出し、ViewModel内のLiveDataにセット。
-updateUIメソッド
 保存名リストのリストビューのsubmitListが抜けていた為、処理を追加。

【修正】
・PreferenceParamDAO.java
-List戻り値をLiveDataに変更。

・PreferenceParamRepository.java
-preferenceParamListをLiveDataのリストに変更。DAOのgetAllの戻り値をここに格納し、このLiveDataを追跡することで変更の通知を非同期に行えるようにする。
-getSave、getSaveNameColumnsListを削除。getAllで取得したデータからソース上で抽出するように(何度も取得するリソースを減らす)

・CustomPreferenceListViewModel.java
-CustomPreferenceData→PreferenceParamを利用するように変更。リポジトリと使用する型を合わせる目的。
-PreferenceDataListをPreferenceParamListにリネーム
-DAOをViewModelで触らないように修正
-リポジトリのLiveDataを追跡する為のフィールド追加。
-addPreferenceData、addDefaultPreferenceDataメソッドの冒頭に、viewModelの保存設定データがまだ存在してなければ、リポジトリのリストをセットする処理を追加。
-updateDAOの処理を一旦削除。
-existingCheckDAOの処理をstream化。
-getSaveNameListメソッドを作成。リポジトリから保存名を抽出し、重複を排除したリストを返す。
-リポジトリのLiveDataを半永続追跡し、変更が通知されたらviewModelのLiveDataにセットする設計に変更。
-repoPreferenceParamListを使用していたところの処理を全てviewModel内のLiveDataを使用するように変更。

・SaveTitleViewOneLineParamViewModel.java
-使用していないエラーが発生していた処理を削除。

・CustomDiscountPreferenceFragment.java
☆onViewCreatedのsetOnClickListenersをviewModelInitialize内のLiveData購読部分に移動。値の更新を受け取ってから初期化を行うようにして、データがない状態からビューを生成しないように修正。
-使用しない処理を削除。
-viewModelのリポジトリのLiveDataを使用していた処理を、viewModelのLiveDataを使用する処理に変更。
-viewModelInitializeメソッド
 customPreferenceViewModelのobserveが2つ存在し、分ける必要がない内容であったため統合。
-updateUIメソッド
 拡張for文をfor文に変更。CustomPreferenceDataのnoの要素に番号を入れたかったため。
 EditTextへのセットタイミングをsubmitListの後に変更し、セットするリストサイズをAdapterのgetItemCountに変更。
-recyclerViewInitializeメソッド
 setHasFixedSizeの設定を削除。これが原因で、初期化時のリスト内のサイズが0の状態で表示数が固定されてしまい、要素追加時にしかリストが更新されなかった。(addPreferenceDataElementメソッド内でsatHazFixedSizeが利用されていて、追加毎に再設定されていたからと思われる。)
-addPreferenceDataElementメソッド
  不要なupdateUIの呼び出しを削除(customPreferenceViewModelのobserveで勝手に呼び出される)

・ResultListFragment.java
☆onViewCreated内の初期化処理をviewModelInitialize内のLiveData購読部分に移動。値の更新を受け取ってから初期化を行うようにして、データがない状態からビューを生成しないように修正。
-viewModelのリポジトリのLiveDataを使用していた処理を、viewModelのLiveDataを使用する処理に変更。