### PR TITLE
Add customdiscountpreferencefragment loadbutton

### DIFF
--- a/app/src/main/java/com/example/discountcalc/customAdapters/SaveDataListViewAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/SaveDataListViewAdapter.java
@@ -6,6 +6,8 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.ListAdapter;
 import androidx.recyclerview.widget.RecyclerView;
@@ -19,6 +21,9 @@ public class SaveDataListViewAdapter
         extends ListAdapter<String, SaveDataListViewAdapter.SaveDataListViewHolder>{
 
     private SavedataListviewOnelineBinding binding;
+
+    // 何番目の読込ボタンが押されたかを記録するフィールド
+    private MutableLiveData<String> loadButtonPushPosition;
 
     public static class SaveDataListViewHolder extends RecyclerView.ViewHolder{
 
@@ -37,7 +42,10 @@ public class SaveDataListViewAdapter
         }
     }
 
-    public SaveDataListViewAdapter(){super(DIFF_CALLBACK);}
+    public SaveDataListViewAdapter(){
+        super(DIFF_CALLBACK);
+        loadButtonPushPosition =new MutableLiveData<>();
+    }
     @NonNull
     @Override
     public SaveDataListViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
@@ -68,11 +76,18 @@ public class SaveDataListViewAdapter
         }
 
         holder.bind(data);
+        holder.binding.buttonLoad.setOnClickListener(v->{
+            loadButtonPushPosition.setValue(data);
+        });
     }
 
     @Override
     public void submitList(@Nullable List<String> list) {
         super.submitList(list);
+    }
+
+    public LiveData<String> PushPosition(){
+        return loadButtonPushPosition;
     }
 
     private static final DiffUtil.ItemCallback<String> DIFF_CALLBACK=

--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -53,6 +54,9 @@ public class CustomDiscountPreferenceFragment extends Fragment {
 
     private AppDataBase dataBase;
 
+    // adapterが持つ、押された読込ボタンの名前情報を購読するフィールド
+    private MutableLiveData<String> useSaveDataNameLiveData;
+
     // ビュー関係
     View view;
     TextView elementNumberViewText;
@@ -67,6 +71,15 @@ public class CustomDiscountPreferenceFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        useSaveDataNameLiveData=new MutableLiveData<>();
+        useSaveDataNameLiveData.observe(getViewLifecycleOwner(),v->{
+            List<PreferenceParam> dataList=loadCustomPreferenceList(useSaveDataNameLiveData.getValue());
+            if(dataList.size()==0) {
+                // ロード先が存在しなければ1個の空要素だけを作成。
+                dataList.add(PreferenceParam.createPreferenceParam("", 0));
+            }
+            updateUI(dataList);
+        });
         bindingElements();
         viewModelInitialize();
         recyclerViewInitialize();
@@ -124,8 +137,8 @@ public class CustomDiscountPreferenceFragment extends Fragment {
             dataList.add(new CustomPreferenceData(i+1,params.get(i).per(),params.get(i).saveName()));
         }
         customPreferenceListAdapter.submitList(new ArrayList<>(Objects.requireNonNull(dataList)));
-        elementNumberViewText.setText(""+customPreferenceListAdapter.getItemCount());
-
+        customPreferenceListView.setHasFixedSize(customPreferenceListAdapter.getItemCount() >= 10);
+        elementNumberViewText.setText("" + customPreferenceListAdapter.getItemCount());
         saveDataListViewAdapter.submitList(new ArrayList<>(customPreferenceViewModel.getSaveNameList()));
     }
 
@@ -187,10 +200,29 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         LinearLayoutManager llm2=new LinearLayoutManager(view.getContext());
         saveDataListView.setLayoutManager(llm2);
         saveDataListView.setAdapter(saveDataListViewAdapter);
+        saveDataListViewAdapter.PushPosition().observe(getViewLifecycleOwner(),v->{
+            // できれば保存前のデータが削除されることを確認するダイアログを出したい。
+            if(customPreferenceViewModel.existingCheckDAO(v)){
+                useSaveDataNameLiveData.setValue(v);
+                saveTitle.setText(v);
+            }
+        });
     }
 
-    // データストアからカスタムの割引率設定に関するデータを取得
-    private void loadCustomPreferenceList(){
+    // 指定された名前の保存されているカスタムの割引率設定に関するデータを取得
+    private List<PreferenceParam> loadCustomPreferenceList(String name) {
+        List<PreferenceParam> dataList = new ArrayList<>();
+        // 引数と一致する保存名のデータをセット
+        if (customPreferenceViewModel.existingCheckDAO(name)) {
+            // TODO リポジトリ内のデータを参照するようにしないとおかしいとは思うが一旦そのまま
+            List<PreferenceParam> params = customPreferenceViewModel.PreferenceParamList().getValue();
+            for(int i=0;i<params.size();i++){
+                if(Objects.equals(params.get(i).saveName(), name)){
+                    dataList.add(new PreferenceParam(dataList.size()+1, params.get(i).saveName(),params.get(i).per()));
+                }
+            }
+        }
+        return dataList;
     }
 
     private void InitializeCustomPreferenceDataSetArrayList(int max) {

--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -220,7 +220,7 @@ public class CustomDiscountPreferenceFragment extends Fragment {
             return false;
         }
         Log.i("saveId","saveID : "+title);
-        if(customPreferenceViewModel.existingCheckDAO(title)){
+        if(!customPreferenceViewModel.existingCheckDAO(title)){
             if(customPreferenceViewModel.saveNewData(title)) {
                 Toast.makeText(getContext(), title + "の名前で保存しました。", Toast.LENGTH_SHORT).show();
             }else{

--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -121,6 +121,16 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         saveTitleViewOneLineParamViewModel=new ViewModelProvider(this,new SaveTitleViewOneLineParamViewModelFactory(requireActivity().getApplication()))
                 .get(SaveTitleViewOneLineParamViewModel.class);
 
+        // 全データ格納用のlivedataを購読
+        customPreferenceViewModel.AllPreferenceParamList().observe(getViewLifecycleOwner(),allParams->{
+            if(allParams.size()>0){
+                customPreferenceViewModel.setPreferenceParamList(useSaveDataNameLiveData.getValue());
+            }
+            // 購読解除することで、最初の一回だけ呼び出されるようにしている。(実装が正しいかは正直不明)
+            // Observer変数を用意し、observe、removeObserver内でそれを使うことで、特定のobserverだけを解除するように変更したい。
+            customPreferenceViewModel.AllPreferenceParamList().removeObservers(getViewLifecycleOwner());
+        });
+
         // ViewModel内のリポジトリLiveDataの購読。
         customPreferenceViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams -> {
             updateUI(preferenceParams);
@@ -214,8 +224,7 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         List<PreferenceParam> dataList = new ArrayList<>();
         // 引数と一致する保存名のデータをセット
         if (customPreferenceViewModel.existingCheckDAO(name)) {
-            // TODO リポジトリ内のデータを参照するようにしないとおかしいとは思うが一旦そのまま
-            List<PreferenceParam> params = customPreferenceViewModel.PreferenceParamList().getValue();
+            List<PreferenceParam> params = customPreferenceViewModel.AllPreferenceParamList().getValue();
             for(int i=0;i<params.size();i++){
                 if(Objects.equals(params.get(i).saveName(), name)){
                     dataList.add(new PreferenceParam(dataList.size()+1, params.get(i).saveName(),params.get(i).per()));

--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -76,7 +76,7 @@ public class CustomDiscountPreferenceFragment extends Fragment {
             List<PreferenceParam> dataList=loadCustomPreferenceList(useSaveDataNameLiveData.getValue());
             if(dataList.size()==0) {
                 // ロード先が存在しなければ1個の空要素だけを作成。
-                dataList.add(PreferenceParam.createPreferenceParam("", 0));
+                dataList.add(PreferenceParam.createDefaultParam());
             }
             updateUI(dataList);
         });

--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -110,17 +110,16 @@ public class CustomDiscountPreferenceFragment extends Fragment {
 
         // ViewModel内のリポジトリLiveDataの購読。
         customPreferenceViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams -> {
-            updateUI();
+            updateUI(preferenceParams);
             setOnClickListeners();
         });
     }
 
-    private void updateUI() {
+    private void updateUI(List<PreferenceParam> params) {
         Log.i("updateUI","updateUI");
 
         List<CustomPreferenceData> dataList=new ArrayList<>();
         // 新しくデータリストを作成し、それをアダプターとTextViewにセットする。
-        List<PreferenceParam> params=customPreferenceViewModel.PreferenceParamList().getValue();
         for (int i=0;i<params.size();i++){
             dataList.add(new CustomPreferenceData(i+1,params.get(i).per(),params.get(i).saveName()));
         }

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -83,6 +83,16 @@ public class ResultListFragment extends Fragment {
         discountCalcViewModel = new ViewModelProvider(requireActivity()).get(DiscountCalcViewModel.class);
         customPreferenceListViewModel =new ViewModelProvider(this,new CustomPreferenceListViewModelFactory(requireActivity().getApplication()))
                 .get(CustomPreferenceListViewModel.class);
+        // 設定データ取得
+        getPreferences();
+
+        customPreferenceListViewModel.AllPreferenceParamList().observe(getViewLifecycleOwner(),allParams->{
+            if(allParams.size()>0){
+                customPreferenceListViewModel.setPreferenceParamList(discountType.name());
+            }
+            // このフラグメントの購読を解除することでフラグメント生成後1度だけ呼ばれるように(できているはず)
+            customPreferenceListViewModel.AllPreferenceParamList().removeObservers(getViewLifecycleOwner());
+        });
 
         // ViewModelのリポジトリLiveDataを購読。
         customPreferenceListViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParams->{
@@ -139,8 +149,6 @@ public class ResultListFragment extends Fragment {
     }
 
     private void loadSettingData() {
-        // 設定データ取得
-        getPreferences();
 
         // 割引率のリスト初期化
         discountPerList=new ArrayList<>();

--- a/app/src/main/java/com/example/discountcalc/params/PreferenceParam.java
+++ b/app/src/main/java/com/example/discountcalc/params/PreferenceParam.java
@@ -14,6 +14,10 @@ public record PreferenceParam (@PrimaryKey(autoGenerate = true) int uid,
         return new PreferenceParam(0,saveName,per);
     }
 
+    public static PreferenceParam createDefaultParam(){
+        return new PreferenceParam(0,"",0);
+    }
+
     @NonNull
     @Override
     public String toString() {

--- a/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
+++ b/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
@@ -20,20 +20,33 @@ import java.util.stream.Collectors;
 public class CustomPreferenceListViewModel extends AndroidViewModel {
 
     private PreferenceParamRepository dataRepository;
-    //private final MutableLiveData<List<CustomPreferenceData>> preferenceDataList;
     private final MutableLiveData<List<PreferenceParam>> preferenceParamList;
+
+    private final MutableLiveData<List<PreferenceParam>> allPreferenceParamList;
     // リポジトリのLiveData追跡用のフィールド
-//    private final LiveData<List<PreferenceParam>> repoPreferenceParamList;
 
 
     public CustomPreferenceListViewModel(Application application){
         super(application);
         dataRepository=new PreferenceParamRepository(application);
         preferenceParamList=new MutableLiveData<>();
-        dataRepository.PreferenceParamList().observeForever(preferenceParamList::setValue);
-//        repoPreferenceParamList= dataRepository.PreferenceParamList();
+        allPreferenceParamList=new MutableLiveData<>();
+        dataRepository.PreferenceParamList().observeForever(allPreferenceParamList::setValue);
+//      repoPreferenceParamList= dataRepository.PreferenceParamList();
     }
 
+    // 全データから使用データする保存名を抽出してlivedataにセット
+    public void setPreferenceParamList(String name){
+        List<PreferenceParam> allData=allPreferenceParamList.getValue();
+        List<PreferenceParam> dataList=new ArrayList<>();
+        if(allData!=null) {
+            dataList = allData.stream().filter(param -> param.saveName().equals(name))
+                    .collect(Collectors.toList());
+        }
+        // 一致データが存在していなかったら初期値を1個セット。
+        if(dataList.size()==0)dataList.add(PreferenceParam.createDefaultParam());
+        preferenceParamList.setValue(dataList);
+    }
     public LiveData<List<PreferenceParam>> PreferenceParamList(){
         return preferenceParamList;
     }

--- a/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
+++ b/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
@@ -32,7 +32,6 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
         preferenceParamList=new MutableLiveData<>();
         allPreferenceParamList=new MutableLiveData<>();
         dataRepository.PreferenceParamList().observeForever(allPreferenceParamList::setValue);
-//      repoPreferenceParamList= dataRepository.PreferenceParamList();
     }
 
     // 全データから使用データする保存名を抽出してlivedataにセット
@@ -50,6 +49,8 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
     public LiveData<List<PreferenceParam>> PreferenceParamList(){
         return preferenceParamList;
     }
+
+    public LiveData<List<PreferenceParam>> AllPreferenceParamList(){return allPreferenceParamList;}
 
     // リポジトリのデータをviewModelにセット
     public void commitPreferenceParamList(){

--- a/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
+++ b/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
@@ -136,7 +136,7 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
 
     //　引数の名前が既に保存されていないか確認
     public boolean existingCheckDAO(String name){
-        return getSaveNameList().stream().noneMatch(name::equals);
+        return getSaveNameList().stream().anyMatch(name::equals);
     }
 
     // リポジトリのデータから保存名のリストを重複を取り除いて抽出


### PR DESCRIPTION
【実装】
・SaveDataListViewAdapter.java
-何番目の読込ボタンが押されたかを記録するフィールドを作成。
読込ボタンが押された際に、そのボタンを持つ要素のindex番号を取得しMutableLiveDataにセット。
外部からはPushPositionメソッドでobserveできるようにしている。

・CustomPreferenceListViewModel.java
-AllPreferenceParamListのgetterメソッドを作成。

・CustomDiscountPreferenceFragment.java
-onViewCreatedメソッド
adapterが持つ、押された読込ボタンの名前情報を購読し、値が更新された時に、その名前の保存されたデータを取得する処理を作成。
-loadCustomPreferenceListメソッド
空メソッドとして置いていたものを、指定された名前の保存されているカスタムの割引率設定に関するデータを取得するメソッドに変更。

・CustomDiscountPreferenceFragment.java
・ResultListFragment.java
-viewModelInitializeメソッド
全データ格納用のlivedataのリストサイズが1以上になったときに、読み込み時に保存名を使ってリストを作成。
初期化時用なのでラムダの最後で購読を解除している。
(Observer変数を別で作成し、removeObserverを使用するように変更したい。)

【修正】
・CustomPreferenceListViewModel.java
-existingCheckDAOメソッドのstreamをnoneMatchからanyMatchに変更。
名前の通りの働きをするように修正。
-CustomPreferenceListViewModelメソッド
不要になったので、コメントアウトしていた処理を削除


・CustomDiscountPreferenceFragment.java
dataListに初期値を追加する際の呼び出しメソッドを変更。
-updateUIメソッド
引数にリストを取り、それをadapterの使用している型でリストを再生成し、セットするように変更。
データ読み込み時のリスト変更に合わせて、リサイクルビューのサイズ固定のオンオフを切り替える処理を追加。
-loadCustomPreferenceListメソッド
使用するviewModelListをAllPreferenceParamListに変更。

・ResultListFragment.java
-loadSettingDataメソッド
getPreferencesの呼び出しタイミングをviewModelInitializeに変更した為削除。タイミングが遅く、例外の原因だった。