### PR TITLE
カスタム割引率設定の要素数表示の修正

### DIFF
--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -148,7 +148,7 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         }
         customPreferenceListAdapter.submitList(new ArrayList<>(Objects.requireNonNull(dataList)));
         customPreferenceListView.setHasFixedSize(customPreferenceListAdapter.getItemCount() >= 10);
-        elementNumberViewText.setText("" + customPreferenceListAdapter.getItemCount());
+        elementNumberViewText.setText("" + dataList.size());
         saveDataListViewAdapter.submitList(new ArrayList<>(customPreferenceViewModel.getSaveNameList()));
     }
 


### PR DESCRIPTION
【修正】
・CustomDiscountPreferenceFragment.java
-updateUIメソッド
要素数の数値表示がadapterのgetItemCount取得だと反映が遅れてしまって、リスト内の要素数とテキストがずれてしまっていたので、一旦UIメソッド内で作成したリストのサイズに変更(このリストをセットしているので問題はないと思う)