### PR TITLE
カスタム割引率設定画面にリスト削除、全削除ボタンを追加。

### DIFF
--- a/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/CustomDiscountPreferenceFragment.java
@@ -65,6 +65,10 @@ public class CustomDiscountPreferenceFragment extends Fragment {
 
     Button saveButton;
 
+    Button clearButton;
+
+    Button allClearButton;
+
     TextView saveTitle;
     int textSize=R.dimen.normal_size;
 
@@ -78,7 +82,7 @@ public class CustomDiscountPreferenceFragment extends Fragment {
                 // ロード先が存在しなければ1個の空要素だけを作成。
                 dataList.add(PreferenceParam.createDefaultParam());
             }
-            updateUI(dataList);
+            customPreferenceViewModel.updatePreferenceData(dataList);
         });
         bindingElements();
         viewModelInitialize();
@@ -113,6 +117,8 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         elementAddButton=customDiscountPreferenceFragmentBinding.AddElementButton;
         changeTextSize=customDiscountPreferenceFragmentBinding.ChangeTextSizeButton;
         saveButton=customDiscountPreferenceFragmentBinding.SaveButton;
+        clearButton=customDiscountPreferenceFragmentBinding.clearElementButton;
+        allClearButton=customDiscountPreferenceFragmentBinding.allClearElementButton;
         saveTitle=customDiscountPreferenceFragmentBinding.saveTitle;
     }
     private void viewModelInitialize() {
@@ -191,6 +197,27 @@ public class CustomDiscountPreferenceFragment extends Fragment {
                 b.setEnabled(true);
             },1000);
             Log.i("button","available");
+        });
+
+        // 一番下の要素を削除
+        clearButton.setOnClickListener(b->{
+            b.setEnabled(false);
+            customPreferenceViewModel.removePreferenceLastData();
+            Handler handler=new Handler();
+            handler.postDelayed(()->{
+                b.setEnabled(true);
+            },100);
+
+        });
+
+        allClearButton.setOnClickListener(b->{
+            b.setEnabled(false);
+            customPreferenceViewModel.allRemovePreferenceData();
+            saveTitle.setText("");
+            Handler handler=new Handler();
+            handler.postDelayed(()->{
+                b.setEnabled(true);
+            },100);
         });
 
     }
@@ -286,11 +313,6 @@ public class CustomDiscountPreferenceFragment extends Fragment {
         // 表示数が10未満の時、リサイクルビューのサイズ変更を固定にする。
         customPreferenceListView.setHasFixedSize(customPreferenceViewModel.listSize() >= 10);
 
-    }
-
-    private boolean removePreferenceDataElement(int removeElementNumber){
-        customPreferenceViewModel.removePreferenceData(removeElementNumber);
-        return true;
     }
 
 

--- a/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
+++ b/app/src/main/java/com/example/discountcalc/viewModels/CustomPreferenceListViewModel.java
@@ -87,31 +87,28 @@ public class CustomPreferenceListViewModel extends AndroidViewModel {
         preferenceParamList.setValue(currentList);
     }
 
-    public void updatePreferenceData(int index,PreferenceParam newData){
-        List<PreferenceParam> currentList=new ArrayList<>(Objects.requireNonNull(preferenceParamList.getValue()));
-        if(index>=0&&index<currentList.size()){
-            currentList.get(index).uid();
-            currentList.get(index).per();
-            preferenceParamList.setValue(currentList);
-        }
-
-    }
-
-    // 指定したインデックスのデータを更新
-    public void updatePreferenceDataAll(List<PreferenceParam> newData) {
-        if (newData != null) {
+    // 保存名から読み込みを行った際に使用する。暫定処理
+    public void updatePreferenceData(List<PreferenceParam> newData){
+        if(newData.size()>1){
             preferenceParamList.setValue(newData);
         }
+
     }
 
-    public void removePreferenceData(int index){
-        if(0<index&&index<preferenceParamList.getValue().size()){
-            preferenceParamList.getValue().remove(index);
+    // リストの最後の要素を削除
+    public void removePreferenceLastData(){
+        if(preferenceParamList.getValue().size()>1) {
+            List<PreferenceParam> dataList=preferenceParamList.getValue();
+            dataList.remove(dataList.size()-1);
+            preferenceParamList.setValue(dataList);
         }
     }
 
-    public void changeTextView(Context context, int index,int value){
-        Objects.requireNonNull(preferenceParamList.getValue()).get(index).uid();
+    // リストの全要素削除
+    public void allRemovePreferenceData(){
+            ArrayList<PreferenceParam> dataList=new ArrayList<>();
+            dataList.add(PreferenceParam.createDefaultParam());
+            preferenceParamList.postValue(dataList);
     }
 
     public boolean saveNewData(@NonNull String saveName){


### PR DESCRIPTION
【実装】
・CustomPreferenceListViewModel.java
-updatePreferenceDataメソッド
保存名から読み込みを行った際に、リストのデータをpreferenceParamListにセットするために実装。暫定処理なので後に修正する可能性有
-removePreferenceLastDataメソッド
preferenceParamListの一番後ろの要素を削除。1個は残すようにしている。
-allRemovePreferenceDataメソッド
preferenceParamListの全要素を削除し、デフォルトのパラメータを1つセットする。

・CustomDiscountPreferenceFragment.java
削除、全削除ボタン用のフィールドを作成
-bindingElementsメソッド
関連付け処理追加

-setOnclickListenersメソッド
clearButton、allClearButtonのクリックイベント処理を追加

【修正】
・CustomPreferenceListViewModel.java
使用していないメソッドを一部削除

・CustomDiscountPreferenceFragment.java
-onViewCreatedメソッド
useSaveDataNameLiveData.observe内のupdateUI呼び出しを削除。customPreferenceViewModel.updatePreferenceDataを呼び出す処理に変更。
このラムダ内で作成したリストを送っていただけでviewModel内のパラメータは変更されておらず、要素追加をした際、数が削除前のリストに追加される形になってしまっていた。