### PR TITLE
Add preferencefragment load database

### DIFF
--- a/app/src/main/java/com/example/discountcalc/fragments/DiscountCalcPreferencesFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/DiscountCalcPreferencesFragment.java
@@ -3,6 +3,7 @@ package com.example.discountcalc.fragments;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 
+import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.NavDirections;
 import androidx.navigation.fragment.NavHostFragment;
@@ -13,6 +14,12 @@ import androidx.preference.PreferenceManager;
 
 import com.example.discountcalc.params.DiscountType;
 import com.example.discountcalc.R;
+import com.example.discountcalc.params.PreferenceParam;
+import com.example.discountcalc.viewModels.CustomPreferenceListViewModel;
+import com.example.discountcalc.viewModels.CustomPreferenceListViewModelFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class DiscountCalcPreferencesFragment extends PreferenceFragmentCompat {
     // 全体の設定データ
@@ -22,13 +29,37 @@ public class DiscountCalcPreferencesFragment extends PreferenceFragmentCompat {
     // カスタム割引率設定移行のPreference
     Preference customDiscountPreference;
 
+    CustomPreferenceListViewModel customPreferenceListViewModel;
+
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.discount_preferences_toppage, rootKey);
         getPreferences();
+        viewModelInitialize();
         // 「使用する設定データ」の初期パラメータに応じて、カスタム割引率を設定するページに移行する項目を表示・非表示させる
         customPreferenceSetting(DiscountType.valueOf(usingCustomPreference.getValue()),customDiscountPreference);
         setOnChangeListener();
+    }
+
+    private void viewModelInitialize() {
+        customPreferenceListViewModel=new ViewModelProvider(this,new CustomPreferenceListViewModelFactory(requireActivity().getApplication()))
+                .get(CustomPreferenceListViewModel.class);
+
+        customPreferenceListViewModel.AllPreferenceParamList().observe(getViewLifecycleOwner(),allParams->{
+            if(allParams.size()>0){
+                customPreferenceListViewModel.AllPreferenceParamList().removeObservers(getViewLifecycleOwner());
+            }
+        });
+
+        customPreferenceListViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParam->{
+            //
+            List<String> loadSaveList=preferenceParam.stream()
+                    .map(PreferenceParam::saveName)
+                    .collect(Collectors.toList());
+            CharSequence entries[]=new CharSequence[loadSaveList.size()];
+
+
+        });
     }
 
     // 設定データ取得

--- a/app/src/main/java/com/example/discountcalc/fragments/DiscountCalcPreferencesFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/DiscountCalcPreferencesFragment.java
@@ -2,7 +2,10 @@ package com.example.discountcalc.fragments;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.NavDirections;
@@ -26,6 +29,9 @@ public class DiscountCalcPreferencesFragment extends PreferenceFragmentCompat {
     SharedPreferences sharedPreferences;
     // 使用する設定データのPreference
     ListPreference usingCustomPreference;
+    // データベースに保存された設定データのリスト
+    ListPreference usingSaveCustomPreference;
+
     // カスタム割引率設定移行のPreference
     Preference customDiscountPreference;
 
@@ -35,9 +41,14 @@ public class DiscountCalcPreferencesFragment extends PreferenceFragmentCompat {
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.discount_preferences_toppage, rootKey);
         getPreferences();
-        viewModelInitialize();
         // 「使用する設定データ」の初期パラメータに応じて、カスタム割引率を設定するページに移行する項目を表示・非表示させる
         customPreferenceSetting(DiscountType.valueOf(usingCustomPreference.getValue()),customDiscountPreference);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        viewModelInitialize();
         setOnChangeListener();
     }
 
@@ -48,17 +59,26 @@ public class DiscountCalcPreferencesFragment extends PreferenceFragmentCompat {
         customPreferenceListViewModel.AllPreferenceParamList().observe(getViewLifecycleOwner(),allParams->{
             if(allParams.size()>0){
                 customPreferenceListViewModel.AllPreferenceParamList().removeObservers(getViewLifecycleOwner());
+                // 重複要素を一つにまとめたリストを作成
+                List<String> loadSaveList = allParams.stream()
+                        .map(PreferenceParam::saveName)
+                        .distinct()
+                        .collect(Collectors.toList());
+
+                // CharSequence[]に保存名のリストをセット
+                // TODO ストリーム使ってうまいこと作れそう
+                int listSize = loadSaveList.size();
+                CharSequence entries[] = new CharSequence[listSize];
+
+                for (int i = 0; i < listSize; i++) {
+                    entries[i] = loadSaveList.get(i);
+                }
+
+                usingSaveCustomPreference.setEntries(entries);
+                usingSaveCustomPreference.setEntryValues(entries);
+                // 初期化時に使用する設定データがカスタム設定になっているなら表示させておく
+                customPreferenceSetting(DiscountType.valueOf(usingCustomPreference.getValue()),usingSaveCustomPreference);
             }
-        });
-
-        customPreferenceListViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),preferenceParam->{
-            //
-            List<String> loadSaveList=preferenceParam.stream()
-                    .map(PreferenceParam::saveName)
-                    .collect(Collectors.toList());
-            CharSequence entries[]=new CharSequence[loadSaveList.size()];
-
-
         });
     }
 
@@ -66,6 +86,7 @@ public class DiscountCalcPreferencesFragment extends PreferenceFragmentCompat {
     private boolean getPreferences(){
         sharedPreferences=PreferenceManager.getDefaultSharedPreferences(requireContext());
         usingCustomPreference = findPreference(getString(R.string.using_setting));
+        usingSaveCustomPreference=findPreference(getString(R.string.using_custom_preference));
         customDiscountPreference=findPreference(getString(R.string.custom_discount_preference));
         // どれか一つでも取得できなければfalseが返される
         return sharedPreferences != null && usingCustomPreference != null && customDiscountPreference != null;
@@ -73,7 +94,14 @@ public class DiscountCalcPreferencesFragment extends PreferenceFragmentCompat {
 
     public void setOnChangeListener() {
         // 使用する設定データの変更リスナー
-        usingCustomPreference.setOnPreferenceChangeListener((preference, newValue) -> customPreferenceSetting(DiscountType.valueOf(newValue.toString()), customDiscountPreference));
+        usingCustomPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+            customPreferenceSetting(DiscountType.valueOf(newValue.toString()), customDiscountPreference);
+            //
+            if(usingSaveCustomPreference.getEntries()!=null){
+                customPreferenceSetting(DiscountType.valueOf(newValue.toString()),usingSaveCustomPreference);
+            }
+            return newValue!=DiscountType.None;
+        });
 
         // カスタム割引率設定の項目クリックリスナー
         customDiscountPreference.setOnPreferenceClickListener(c -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,5 @@
     <string name="saveDataListTitle">保存されたデータ</string>
     <string name="saveButtonText">保存</string>
     <string name="saveName">保存する名前</string>
+    <string name="using_custom_preference">using_custom_preference</string>
 </resources>

--- a/app/src/main/res/xml/discount_preferences_toppage.xml
+++ b/app/src/main/res/xml/discount_preferences_toppage.xml
@@ -20,6 +20,11 @@
             app:isPreferenceVisible="false"
             />
 
+        <ListPreference
+            app:key="@string/using_custom_preference"
+            app:title="使用するカスタム割引率設定データ"
+            />
+
 
         <SeekBarPreference
             app:title="表示数"

--- a/app/src/main/res/xml/discount_preferences_toppage.xml
+++ b/app/src/main/res/xml/discount_preferences_toppage.xml
@@ -12,6 +12,13 @@
             app:title="使用する設定データ"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            app:key="@string/using_custom_preference"
+            app:title="使用するカスタム割引率設定データ"
+            app:useSimpleSummaryProvider="true"
+            app:isPreferenceVisible="false"
+            />
+
         <Preference
             app:fragment="com.example.discountcalc.Fragments.CustomDiscountSetting"
             app:key="@string/custom_discount_preference"
@@ -19,12 +26,6 @@
             app:icon="@drawable/ic_list"
             app:isPreferenceVisible="false"
             />
-
-        <ListPreference
-            app:key="@string/using_custom_preference"
-            app:title="使用するカスタム割引率設定データ"
-            />
-
 
         <SeekBarPreference
             app:title="表示数"
@@ -34,14 +35,6 @@
             app:defaultValue="10"
             app:showSeekBarValue="true"
             />
-
-        <CheckBoxPreference
-            app:key="@string/is_save_parameters"
-            app:title="パラメータの保存"
-            app:summary="アプリ終了時、設定されたパラメータを保存します。表示数には適用されません。"
-            app:defaultValue="true"
-            />
-
 
     </PreferenceCategory>
 


### PR DESCRIPTION
【実装】
・DiscountCalcPreferencesFragment.java
-viewModelInitializeメソッド
CustomPreferenceListViewModelの初期化、observe処理を作成。(未完成)
onCreatePreferencesで呼び出し。
取得したデータリストから保存名を、重複要素を一つにまとめたリストに置き換えて、ListPreferenceにセット。
データベースに保存された設定データリストのフィールドを追加。
onViewCreatedメソッドを作成。

・discount_preferences_toppage.xml
使用するカスタム設定データ項目を追加。
データベースから読み込んだカスタム割引率設定データリストを表示し、この設定項目に表示させる予定
使用するカスタム割引率設定データの選択中の項目を表示するように。
また、デフォルト非表示に(ソース側で表示非表示操作)

・strings.xml
使用するカスタム割引率設定のキーを追加

【修正】
・DiscountCalcPreferencesFragment.java
-onCreatePreferencesメソッド
viewModelInitialize、setOnChangeListenerをOnViewCreatedに移動
-setOnChangeListenerメソッド
usingCustomPreferenceの変更イベントにusingSaveCustomPreferenceの表示・非表示を追加。要素がなければスルーするようにしている(例外の原因になるため)

・discount_preferences_toppage.xml
使用するカスタム割引率設定データの表示位置を調整。
使用していなかったチェックボックスの項目を削除。
