### PR TITLE
sqliteのデータベース名・テーブル名等、複数の箇所で使用するクエリ文字列を定数にして使用できるようにする。

### DIFF
--- a/app/src/main/java/com/example/discountcalc/DAO/PreferenceParamDAO.java
+++ b/app/src/main/java/com/example/discountcalc/DAO/PreferenceParamDAO.java
@@ -10,6 +10,7 @@ import androidx.room.Update;
 import androidx.room.Upsert;
 import androidx.sqlite.db.SupportSQLiteQuery;
 
+import com.example.discountcalc.dataBase.DataBaseStrings;
 import com.example.discountcalc.params.PreferenceParam;
 import com.example.discountcalc.params.SQLiteTableInfo;
 
@@ -34,18 +35,18 @@ public interface PreferenceParamDAO {
 
     @Delete int delete(PreferenceParam param);
 
-    @Query("DELETE FROM custom_preference_table where save_name=:saveName")
+    @Query("DELETE FROM "+ DataBaseStrings.TableName +" where save_name=:saveName")
     int deleteForSaveName(String saveName);
-    @Query("DELETE FROM custom_preference_table")
+    @Query("DELETE FROM "+DataBaseStrings.TableName)
     int deleteAll();
 
-    @Query("SELECT * FROM custom_preference_table")
+    @Query("SELECT * FROM "+DataBaseStrings.TableName)
     LiveData<List<PreferenceParam>> getAll();
 
-    @Query("SELECT uid,save_name,per FROM custom_preference_table WHERE save_name LIKE :saveName")
+    @Query("SELECT uid,save_name,per FROM "+DataBaseStrings.TableName+" WHERE save_name LIKE :saveName")
     LiveData<List<PreferenceParam>> getSave(String saveName);
 
-    @Query("SELECT DISTINCT save_name from custom_preference_table")
+    @Query("SELECT DISTINCT save_name FROM "+DataBaseStrings.TableName)
     LiveData<List<String>> getSaveNameColumnsList();
 
     @RawQuery

--- a/app/src/main/java/com/example/discountcalc/dataBase/AppDataBase.java
+++ b/app/src/main/java/com/example/discountcalc/dataBase/AppDataBase.java
@@ -24,7 +24,7 @@ public abstract class AppDataBase extends RoomDatabase {
         if(instance==null){
             synchronized (AppDataBase.class){
                 if(instance==null){
-                    instance= Room.databaseBuilder(context.getApplicationContext(), AppDataBase.class,"custom_preference_table").build();
+                    instance= Room.databaseBuilder(context.getApplicationContext(), AppDataBase.class,DataBaseStrings.DataBaseName).build();
                 }
             }
         }

--- a/app/src/main/java/com/example/discountcalc/dataBase/DataBaseStrings.java
+++ b/app/src/main/java/com/example/discountcalc/dataBase/DataBaseStrings.java
@@ -1,0 +1,8 @@
+package com.example.discountcalc.dataBase;
+
+public final class DataBaseStrings {
+    public final static String DataBaseName="custom_preference_database";
+
+    public final static String TableName="custom_preference_table";
+
+}


### PR DESCRIPTION
【実装】
・DataBaseStrings.java
DataBaseNameとTableNameを定義。

【修正】
・AppDataBase.java
「custom_preference_table」をDataBaseStringsに定義した定数に変更。
また、テーブル名と重複してしまっていた為修正。

・PreferenceParamDAO.java
クエリ内の「custom_preference_table」をDataBaseStringsに定義した定数変更