### PR TITLE
ツールバーをタイトルだけでなく、全ての場面で表示するように。

### DIFF
--- a/app/src/main/java/com/example/discountcalc/activity/MainActivity.java
+++ b/app/src/main/java/com/example/discountcalc/activity/MainActivity.java
@@ -5,13 +5,18 @@ import android.os.Bundle;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
 
+import com.example.discountcalc.R;
 import com.example.discountcalc.databinding.ActivityMainBinding;
+import com.example.discountcalc.fragments.CustomToolBar;
+import com.example.discountcalc.fragments.ToolBarFragment;
 
 public class MainActivity extends AppCompatActivity{
     private ActivityMainBinding binding;
 
-
+    private CustomToolBar customToolBar;
+    ToolBarFragment toolBarFragment;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -19,12 +24,19 @@ public class MainActivity extends AppCompatActivity{
         binding = ActivityMainBinding.inflate(getLayoutInflater());
 
         setContentView(binding.getRoot());
+
+        toolBarFragment=new ToolBarFragment();
     }
 
 
     @Override
     protected void onStart() {
         super.onStart();
+
+        FragmentManager fragmentManager=getSupportFragmentManager();
+        fragmentManager.beginTransaction()
+                .add(R.id.Main_ToolBarView,toolBarFragment)
+                .commit();
 
         // 空白箇所タップでフォーカスを外す(子フラグメントのeditText用)
         binding.getRoot().setOnClickListener(v->{

--- a/app/src/main/java/com/example/discountcalc/activity/MainActivity.java
+++ b/app/src/main/java/com/example/discountcalc/activity/MainActivity.java
@@ -9,13 +9,11 @@ import androidx.fragment.app.FragmentManager;
 
 import com.example.discountcalc.R;
 import com.example.discountcalc.databinding.ActivityMainBinding;
-import com.example.discountcalc.fragments.CustomToolBar;
 import com.example.discountcalc.fragments.ToolBarFragment;
 
 public class MainActivity extends AppCompatActivity{
     private ActivityMainBinding binding;
 
-    private CustomToolBar customToolBar;
     ToolBarFragment toolBarFragment;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -33,9 +31,10 @@ public class MainActivity extends AppCompatActivity{
     protected void onStart() {
         super.onStart();
 
+        // ツールバーフラグメントを配置
         FragmentManager fragmentManager=getSupportFragmentManager();
         fragmentManager.beginTransaction()
-                .add(R.id.Main_ToolBarView,toolBarFragment)
+                .replace(R.id.Main_ToolBarView,toolBarFragment)
                 .commit();
 
         // 空白箇所タップでフォーカスを外す(子フラグメントのeditText用)

--- a/app/src/main/java/com/example/discountcalc/fragments/TitleFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/TitleFragment.java
@@ -54,11 +54,11 @@ public class TitleFragment extends Fragment implements CustomTextWatcher {
         calcTitleBinding.priceTextField.addTextChangedListener(this);
 
         // ツールバーFragment設定
-        ToolBarFragment toolBarFragment=new ToolBarFragment();
-        getChildFragmentManager().beginTransaction()
-                .replace(R.id.title_ToolBarView, toolBarFragment)
-                .setReorderingAllowed(true)
-                .commit();
+//        ToolBarFragment toolBarFragment=new ToolBarFragment();
+//        getChildFragmentManager().beginTransaction()
+//                .replace(R.id.title_ToolBarView, toolBarFragment)
+//                .setReorderingAllowed(true)
+//                .commit();
 
         // 結果表示Fragment設定
         ResultListFragment resultListFragment=new ResultListFragment();

--- a/app/src/main/java/com/example/discountcalc/fragments/ToolBarFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ToolBarFragment.java
@@ -10,7 +10,6 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
 import androidx.navigation.NavDirections;
-import androidx.navigation.Navigation;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.example.discountcalc.R;
@@ -36,9 +35,9 @@ public class ToolBarFragment extends Fragment implements ToolBarCustomViewDelega
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         binding=FragmentOriginalToolbarBinding.inflate(inflater,container,false);
 
-        setCustomToolBar(inflater);
         navHostFragment=(NavHostFragment) requireActivity().getSupportFragmentManager().findFragmentById(R.id.host_fragment);
-
+        navController=navHostFragment.getNavController();
+        setCustomToolBar(inflater);
         assert navHostFragment != null:"null navHostFragment. TitleFragment.java line:89";
         return binding.getRoot();
     }
@@ -51,9 +50,13 @@ public class ToolBarFragment extends Fragment implements ToolBarCustomViewDelega
 //        customToolBar.configure(title,false,false);
         binding.ActionTitle.setText(title);
 
-        setLeftButton(isHideLeftButton);
+        // navGraphのフラグメントが切り替わった時のイベントリスナーを追加
+        navController.addOnDestinationChangedListener((((navController1, navDestination, bundle) -> {
+            setLeftButton(isHideLeftButton);
 
-        setRightButton(isHideRightButton);
+            setRightButton(isHideRightButton);
+        })));
+
 
 //        // カスタムツールバーを挿入するコンテナを指定
 //        LinearLayoutCompat layoutCompat=binding.layoutCustomToolbar;
@@ -94,19 +97,51 @@ public class ToolBarFragment extends Fragment implements ToolBarCustomViewDelega
     @Override
     public void onClickedLeftButton() {
         Log.i("ToolBarOnClicked","onClickedLeftButton");
+        if (navController.getCurrentDestination() != null) {
+            int id =  navController.getCurrentDestination().getId();
+            CharSequence label=navController.getCurrentDestination().getLabel();
+
+            // タイトル画面時の処理
+            if (id == R.id.nav_titleFragment) {
+                Log.i("toolBarFragment", "current fragment:" + label);
+            }
+            // 設定トップ画面時の処理
+            if (id == R.id.nav_settingsFragment
+                    || id ==R.id.nav_customDiscountPreferenceFragment) {
+                Log.i("toolBarFragment", "current fragment:" + label);
+                navController.popBackStack();
+            }
+//            // カスタム割引率設定画面の処理
+//            if (id == R.id.nav_customDiscountPreferenceFragment) {
+//                Log.i("toolBarFragment", "current fragment:" + label);
+//            }
+        }
     }
 
     @Override
     public void onClickedRightButton() {
         Log.i("ToolBarOnClicked","onClickedRightButton");
+        if (navController.getCurrentDestination() != null) {
+            int id =  navController.getCurrentDestination().getId();
+            CharSequence label=navController.getCurrentDestination().getLabel();
 
-    }
-
-    // navigationGraphのDestination遷移を実装
-    private void setNavGraphDestination(){
-        NavController navHostController=navHostFragment.getNavController();
-        NavDirections navDirections=TitleFragmentDirections.actionTitleFragmentToSettingsFragment();
-        navHostController.navigate(navDirections);
+            // タイトル画面時の処理
+            if (id == R.id.nav_titleFragment) {
+                navController.navigate(R.id.nav_settingsFragment);
+                Log.i("toolBarFragment", "next:" + R.id.nav_settingsFragment);
+            }
+            // 設定トップ画面時の処理
+            if (id == R.id.nav_settingsFragment
+                    || id == R.id.nav_customDiscountPreferenceFragment) {
+                navController.navigate(R.id.nav_titleFragment);
+                Log.i("toolBarFragment", "Go To Home");
+            }
+//            // カスタム割引率設定画面の処理
+//            if (id == R.id.nav_customDiscountPreferenceFragment) {
+//                Log.i("toolBarFragment", "current fragment:" + label);
+//
+//            }
+        }
     }
 
     private void setNavGraphMovement(NavDirections nextFragment){

--- a/app/src/main/java/com/example/discountcalc/fragments/ToolBarFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ToolBarFragment.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
 import androidx.navigation.NavDirections;
+import androidx.navigation.Navigation;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.example.discountcalc.R;
@@ -21,6 +22,10 @@ public class ToolBarFragment extends Fragment implements ToolBarCustomViewDelega
 
     boolean isHideLeftButton=false;
     boolean isHideRightButton=false;
+
+    NavHostFragment navHostFragment;
+    NavController navController;
+
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -32,7 +37,9 @@ public class ToolBarFragment extends Fragment implements ToolBarCustomViewDelega
         binding=FragmentOriginalToolbarBinding.inflate(inflater,container,false);
 
         setCustomToolBar(inflater);
+        navHostFragment=(NavHostFragment) requireActivity().getSupportFragmentManager().findFragmentById(R.id.host_fragment);
 
+        assert navHostFragment != null:"null navHostFragment. TitleFragment.java line:89";
         return binding.getRoot();
     }
 
@@ -92,16 +99,22 @@ public class ToolBarFragment extends Fragment implements ToolBarCustomViewDelega
     @Override
     public void onClickedRightButton() {
         Log.i("ToolBarOnClicked","onClickedRightButton");
-        setNavGraphDestination();
+
     }
 
     // navigationGraphのDestination遷移を実装
     private void setNavGraphDestination(){
-        NavHostFragment navHostFragment=(NavHostFragment) requireActivity().getSupportFragmentManager().findFragmentById(R.id.host_fragment);
-        assert navHostFragment != null:"null navHostFragment. TitleFragment.java line:89";
         NavController navHostController=navHostFragment.getNavController();
         NavDirections navDirections=TitleFragmentDirections.actionTitleFragmentToSettingsFragment();
         navHostController.navigate(navDirections);
+    }
+
+    private void setNavGraphMovement(NavDirections nextFragment){
+        NavController navHostController=navHostFragment.getNavController();
+        if(nextFragment!=null) {
+            navHostController.navigate(nextFragment);
+        }
+
     }
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    tools:context=".MainActivity">
+    tools:context=".activity.MainActivity">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/Main_ToolBarView"
+        android:layout_width="0dp"
+        android:layout_height="80dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/host_fragment"
@@ -14,12 +23,11 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:defaultNavHost="true"
-        app:navGraph="@navigation/nav_graph"
-
         app:layout_constraintLeft_toLeftOf="parent"
+
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
+        app:layout_constraintTop_toBottomOf="@+id/Main_ToolBarView"
+        app:navGraph="@navigation/nav_graph" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/calc_title.xml
+++ b/app/src/main/res/layout/calc_title.xml
@@ -6,29 +6,19 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/title_ToolBarView"
-        android:layout_width="0dp"
-        android:layout_height="80dp"
-
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:layout="@layout/fragment_original_toolbar" />
-
 
     <TextView
         android:id="@+id/unitLabel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="24dp"
         android:paddingTop="8dp"
         android:text="@string/unitLabelText"
         android:textSize="@dimen/large_size"
         android:textStyle="normal"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title_ToolBarView" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
         android:id="@+id/priceTextField"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,40 +3,40 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/titleFragment">
+    app:startDestination="@id/nav_titleFragment">
 
     <fragment
-        android:id="@+id/titleFragment"
+        android:id="@+id/nav_titleFragment"
         android:name="com.example.discountcalc.fragments.TitleFragment"
         android:label="TitleFragment"
         tools:layout="@layout/calc_title">
         <action
             android:id="@+id/action_titleFragment_to_settingsFragment"
-            app:destination="@id/settingsFragment"
-            app:popUpTo="@id/titleFragment"
+            app:destination="@id/nav_settingsFragment"
+            app:popUpTo="@id/nav_titleFragment"
             app:popUpToInclusive="false" />
     </fragment>
     <fragment
-        android:id="@+id/settingsFragment"
+        android:id="@+id/nav_settingsFragment"
         android:name="com.example.discountcalc.fragments.DiscountCalcPreferencesFragment"
         android:label="SettingsFragment"
         tools:layout="@layout/config_main">
         <action
             android:id="@+id/action_settingsFragment_to_titleFragment"
-            app:destination="@id/titleFragment"
-            app:popUpTo="@id/titleFragment" />
+            app:destination="@id/nav_titleFragment"
+            app:popUpTo="@id/nav_titleFragment" />
         <action
             android:id="@+id/action_settingsFragment_to_customDiscountPreferenceFragment"
-            app:destination="@id/customDiscountPreferenceFragment" />
+            app:destination="@id/nav_customDiscountPreferenceFragment" />
     </fragment>
     <fragment
-        android:id="@+id/customDiscountPreferenceFragment"
+        android:id="@+id/nav_customDiscountPreferenceFragment"
         android:name="com.example.discountcalc.fragments.CustomDiscountPreferenceFragment"
         android:label="custom_discount_preference_fragment"
         tools:layout="@layout/custom_discount_preference_fragment" >
         <action
             android:id="@+id/action_customDiscountPreferenceFragment_to_settingsFragment"
-            app:destination="@id/settingsFragment" />
+            app:destination="@id/nav_settingsFragment" />
     </fragment>
     <!--Global Action-->
 </navigation>


### PR DESCRIPTION
【実装】
・ToolBarFragment.java
-OnCreateViewメソッド
navControllerを取得する処理を追加

-setCustomToolBarメソッド
左ボタン、右ボタンが押された時の処理を書いたメソッドをnavGraph内のフラグメントが切り替わりに応じて変化するように。

-onClickedLeftButtonメソッド
左上の「戻る」アイコンをタップしたときに、そのときに表示しているフラグメントに応じて移動先を変化するように
タイトル：なにもなし
それ以外：一つ手前の画面に戻る
ここの移動処理やアイコン表示は要調整

-onClickedRightButtonメソッド
右上の「設定」アイコンをタップしたときに、そのときに表示しているフラグメントに応じて移動先を変化するように
タイトル：設定トップ画面移動
それ以外：タイトルに戻る

【修正】
・MainActivity.java
-フィールド
不要なフィールドを削除

-onStartメソッド
ツールバーを配置する処理をaddでなくreplaceにして、フラグメントを置き換えるように
処理のコメント追加

・ToolBarFragment.java
-OnCreateViewメソッド
setCustomToolBarの呼び出し位置を変更。navControllerを取得する前に呼び出してnullExceptionを吐き出してしまうため。

-setNavGraphDestinationメソッド
使用しないため処理を削除

・nav_graph.xml
navGraphに配置した各フラグメントのidに「nav_」の修飾を追加してnavigation処理を行うときにわかりやすいように修正