### PR TITLE
レイアウトのズレ修正

### DIFF
--- a/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
@@ -1,6 +1,6 @@
 package com.example.discountcalc.customAdapters;
 
-import android.util.Log;
+import android.graphics.Point;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -14,6 +14,7 @@ import com.example.discountcalc.params.DiscountData;
 import com.example.discountcalc.R;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Locale;
 
 /**
@@ -23,6 +24,9 @@ public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapte
 
     private ArrayList<DiscountData> localData;
     private int[]  paddings;
+
+    // resultPriceListViewのid,layout_width,Layout_heightを格納
+    private HashMap<Integer,Point> adapterLayoutSize;
 
     /**
      * 1行分のViewの参照を保持するホルダークラス
@@ -71,6 +75,13 @@ public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapte
         }
     }
 
+    /// resultLabelのid,layout_width,Layout_heightを格納
+    public ResultLayoutAdapter(ArrayList<DiscountData>dataset, HashMap<Integer,Point>layoutSize){
+        localData=dataset;
+        adapterLayoutSize=layoutSize;
+
+    }
+
     // 新しい1行分のビューを作成(レイアウトマネージャーによって呼び出される)
     @NonNull
     @Override
@@ -93,9 +104,13 @@ public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapte
         holder.discountPriceTextview.setGravity(Gravity.END);
         holder.priceTextview.setGravity(Gravity.END);
 
-        // 価格表示の余白を変更
-        holder.priceTextview.setPadding(paddings[0],paddings[1],paddings[2],paddings[3]);
-        Log.i("info","Data:"+position);
+        // ヘッダーのサイズに合わせる
+        if(adapterLayoutSize !=null){
+            applySize(holder.discountTextview,adapterLayoutSize.get(R.id.discountLabel));
+            applySize(holder.discountPriceTextview,adapterLayoutSize.get(holder.discountPriceTextview.getId()));
+            applySize(holder.priceTextview,adapterLayoutSize.get(holder.priceTextview.getId()));
+        }
+
     }
     // データセットのサイズを返す (レイアウトマネージャによって呼び出される)
     @Override
@@ -108,6 +123,14 @@ public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapte
         localData=data;
         // localDataのサイズ分の変更をobserverに通知
         notifyItemRangeChanged(0,getItemCount());
+    }
+
+    private void applySize(TextView textView,Point size){
+        if(size == null)return;
+        ViewGroup.LayoutParams lp=textView.getLayoutParams();
+        lp.width = size.x;
+        lp.height=size.y;
+        textView.setLayoutParams(lp);
     }
 
 

--- a/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
@@ -23,7 +23,6 @@ import java.util.Locale;
 public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapter.ResultViewHolder> {
 
     private ArrayList<DiscountData> localData;
-    private int[]  paddings;
 
     // resultPriceListViewのid,layout_width,Layout_heightを格納
     private HashMap<Integer,Point> adapterLayoutSize;
@@ -66,14 +65,6 @@ public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapte
         localData=dataset;
     }
 
-    public ResultLayoutAdapter(ArrayList<DiscountData> dataset,int paddingPx,boolean[] paddingFlags){
-        localData=dataset;
-        //int型で配列作成し、paddingFlagsがtrueなら設定した数値分の余白を空ける
-        paddings=new int[paddingFlags.length];
-        for (int i=0;i<paddings.length;i++){
-            paddings[i]=(paddingFlags[i]?1:0)*paddingPx;
-        }
-    }
 
     /// resultLabelのid,layout_width,Layout_heightを格納
     public ResultLayoutAdapter(ArrayList<DiscountData>dataset, HashMap<Integer,Point>layoutSize){

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -1,6 +1,7 @@
 package com.example.discountcalc.fragments;
 
 import android.content.SharedPreferences;
+import android.graphics.Point;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -16,6 +17,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TableRow;
 
 import com.example.discountcalc.calculationPack.ConvertDisplayUnitsHelper;
 import com.example.discountcalc.calculationPack.DiscountCalc;
@@ -29,6 +31,7 @@ import com.example.discountcalc.viewModels.DiscountCalcViewModel;
 import com.example.discountcalc.databinding.ResultPriceListBinding;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 
 @SuppressWarnings("FieldCanBeLocal")
@@ -42,6 +45,9 @@ public class ResultListFragment extends Fragment {
     // 価格
     private int price=0;
     private View view;
+
+    private TableRow resultOneCalcView;
+
 
     SharedPreferences preferences;
 
@@ -143,6 +149,9 @@ public class ResultListFragment extends Fragment {
         // Inflate the layout for this fragment
         resultPriceListBinding = ResultPriceListBinding.inflate(inflater, container, false);
         view = resultPriceListBinding.getRoot();
+        resultOneCalcView=resultPriceListBinding.resultLabel.resultLabelPackage;
+
+
         Log.i("resultFragment", getParentFragmentManager().toString());
 
         return view;
@@ -244,6 +253,24 @@ public class ResultListFragment extends Fragment {
         // 使用する割引率設定を更新しておく。
         String saveKey=getString(R.string.using_setting);
         preferences.edit().putString(saveKey,discountType.toString()).apply();
+    }
+
+    private HashMap<Integer, Point> getOneCalcViewLayoutWidthAndHeight() {
+        final HashMap<Integer, Point> layoutSize = new HashMap<>();
+        layoutSize.put(R.id.discountLabel, new Point(
+                resultOneCalcView.findViewById(R.id.discountLabel).getWidth(),
+                resultOneCalcView.findViewById(R.id.discountLabel).getHeight()
+        ));
+        layoutSize.put(R.id.discountPriceLabel, new Point(
+                resultOneCalcView.findViewById(R.id.discountPriceLabel).getWidth(),
+                resultOneCalcView.findViewById(R.id.discountPriceLabel).getHeight()
+        ));
+        layoutSize.put(R.id.priceLabel, new Point(
+                resultOneCalcView.findViewById(R.id.priceLabel).getWidth(),
+                resultOneCalcView.findViewById(R.id.priceLabel).getHeight()
+        ));
+
+        return layoutSize;
     }
 
 }

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -73,10 +73,14 @@ public class ResultListFragment extends Fragment {
 
         // Get the ViewModel.
         Log.i("ResultListFragment", "Called ViewModelProvider.get");
-        viewModelInitialize();
 
+    }
 
+    @Override
+    public void onStart() {
+        super.onStart();
 
+        view.post(this::viewModelInitialize);
     }
 
     private void viewModelInitialize() {

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -19,7 +19,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TableRow;
 
-import com.example.discountcalc.calculationPack.ConvertDisplayUnitsHelper;
 import com.example.discountcalc.calculationPack.DiscountCalc;
 import com.example.discountcalc.customAdapters.ResultLayoutAdapter;
 import com.example.discountcalc.params.DiscountType;
@@ -120,7 +119,9 @@ public class ResultListFragment extends Fragment {
             paddingFlags[2] = true;
 
             recyclerView = resultPriceListBinding.resultPriceList;
-            resultLayoutAdapter = new ResultLayoutAdapter(resultDataList, ConvertDisplayUnitsHelper.dpToPx(30, requireContext()), paddingFlags);
+
+            resultLayoutAdapter = new ResultLayoutAdapter(resultDataList, getOneCalcViewLayoutWidthAndHeight());
+
             // 縦方向のLayoutManagerを作成
             LinearLayoutManager llm = new LinearLayoutManager(resultPriceListBinding.getRoot().getContext());
             recyclerView.setHasFixedSize(true);

--- a/app/src/main/res/layout/result_one_calc_view.xml
+++ b/app/src/main/res/layout/result_one_calc_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TableRow xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/result_label_package"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/result_one_calc_view.xml
+++ b/app/src/main/res/layout/result_one_calc_view.xml
@@ -3,6 +3,7 @@
     android:id="@+id/result_label_package"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:baselineAligned="false"
     android:weightSum="10">
 
     <TextView
@@ -12,9 +13,6 @@
         android:layout_weight="1"
         android:background="@drawable/shape_outer_frame"
         android:gravity="center"
-        android:padding="1dip"
-        android:scrollbarStyle="insideOverlay"
-        android:scrollHorizontally="true"
         android:text="@string/discountRate"
         android:textSize="@dimen/normal_size" />
 
@@ -25,9 +23,6 @@
         android:layout_weight="3"
         android:background="@drawable/shape_outer_frame"
         android:gravity="center"
-        android:padding="1dip"
-        android:scrollbarStyle="insideOverlay"
-        android:scrollHorizontally="true"
         android:text="@string/discountLabel"
         android:textSize="@dimen/normal_size" />
 
@@ -38,9 +33,6 @@
         android:layout_weight="6"
         android:background="@drawable/shape_outer_frame"
         android:gravity="center"
-        android:padding="1dip"
-        android:scrollbarStyle="insideOverlay"
-        android:scrollHorizontally="true"
         android:text="@string/priceLabel"
         android:textSize="@dimen/normal_size" />
 </TableRow>

--- a/app/src/main/res/layout/result_one_calc_view.xml
+++ b/app/src/main/res/layout/result_one_calc_view.xml
@@ -1,60 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<TableRow xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/result_label_package"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
-
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/discountBarrier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="end"
-        app:constraint_referenced_ids="discountLabel" />
-
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/discountPriceBarrier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="end"
-        app:constraint_referenced_ids="discountPriceLabel" />
+    android:layout_height="wrap_content"
+    android:weightSum="10">
 
     <TextView
         android:id="@+id/discountLabel"
-        android:layout_width="80dp"
-        android:layout_height="40dp"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
         android:background="@drawable/shape_outer_frame"
         android:gravity="center"
         android:padding="1dip"
+        android:scrollbarStyle="insideOverlay"
+        android:scrollHorizontally="true"
         android:text="@string/discountRate"
-        android:textSize="24sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:textSize="@dimen/normal_size" />
 
     <TextView
         android:id="@+id/discountPriceLabel"
-        android:layout_width="120dp"
-        android:layout_height="40dp"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_weight="3"
         android:background="@drawable/shape_outer_frame"
         android:gravity="center"
         android:padding="1dip"
+        android:scrollbarStyle="insideOverlay"
+        android:scrollHorizontally="true"
         android:text="@string/discountLabel"
-        android:textSize="24sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@id/discountBarrier"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:textSize="@dimen/normal_size" />
 
     <TextView
         android:id="@+id/priceLabel"
-        android:layout_width="0dp"
-        android:layout_height="40dp"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_weight="6"
         android:background="@drawable/shape_outer_frame"
         android:gravity="center"
         android:padding="1dip"
+        android:scrollbarStyle="insideOverlay"
+        android:scrollHorizontally="true"
         android:text="@string/priceLabel"
-        android:textSize="24sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/discountPriceLabel"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:textSize="@dimen/normal_size" />
+</TableRow>

--- a/app/src/main/res/layout/result_price_list.xml
+++ b/app/src/main/res/layout/result_price_list.xml
@@ -1,39 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/resultPriceListView"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:weightSum="10"
+    android:baselineAligned="false"
+    >
 
     <include
         android:id="@+id/resultLabel"
         layout="@layout/result_one_calc_view"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/resultPriceList"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/resultLabel" />
+        app:layout_constraintTop_toBottomOf="@+id/resultLabel"
+        android:layout_weight="1"
+        tools:ignore="InefficientWeight" />
 
     <TextView
         android:id="@+id/cautionaryNote"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
         android:layout_marginTop="32dp"
 
         android:layout_marginEnd="32dp"
-        android:textSize="@dimen/small_size"
-        android:text="@string/result_view_under_message"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/resultPriceList" />
+        android:text="@string/result_view_under_message" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>


### PR DESCRIPTION
Adapterにヘッダーとして利用している1行レイアウトの縦横サイズをHashMapで送る処理を作成
holder作成時に適用させる。
ResultLayoutAdapterのコンストラクタを追加。使用しなくなったコンストラクタとフィールドを削除。

結果表示のフラグメントをLinearLayoutに変更。
文字サイズが大きく、端末解像度が小さいと、UIが画面外にはみ出してしまうので要修正(issues作成後にマージする)

viewModelInitializeのタイミングをonStartに移動+view.postでUI描画後に行うように修正。
Activityが取得できずエラー落ちしていたものが修正できたと思う。