### PR TITLE
ResultLayoutAdapterをListAdapterに改修

### DIFF
--- a/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
@@ -24,7 +24,6 @@ import java.util.Locale;
  **/
 public class ResultLayoutAdapter extends ListAdapter<DiscountData,ResultLayoutAdapter.ResultViewHolder> {
 
-    private ArrayList<DiscountData> localData;
 
     // resultPriceListViewのid,layout_width,Layout_heightを格納
     private final HashMap<Integer, Point> adapterLayoutSize;
@@ -54,17 +53,10 @@ public class ResultLayoutAdapter extends ListAdapter<DiscountData,ResultLayoutAd
      * アダプタのデータセットを初期化
      * RecycleViewで使用されるビューに入力するデータを含む
      */
-    public ResultLayoutAdapter(ArrayList<DiscountData> dataset)
-    {
-        localData=dataset;
-    }
-
-
     /// resultLabelのid,layout_width,Layout_heightを格納
-    public ResultLayoutAdapter(ArrayList<DiscountData>dataset, HashMap<Integer,Point>layoutSize){
-        localData=dataset;
-        adapterLayoutSize=layoutSize;
-
+    public ResultLayoutAdapter(HashMap<Integer, Point> layoutSize) {
+        super(DIFF_CALLBACK);
+        adapterLayoutSize = layoutSize;
     }
 
     // 新しい1行分のビューを作成(レイアウトマネージャーによって呼び出される)
@@ -80,10 +72,11 @@ public class ResultLayoutAdapter extends ListAdapter<DiscountData,ResultLayoutAd
     // ビューの内容を置き換える(レイアウトマネージャーによって呼び出される)
     @Override
     public void onBindViewHolder(@NonNull ResultViewHolder holder, int position) {
+        DiscountData data=getItem(position);
         // この位置のデータセットから要素を取得し、ビューの内容をその要素で置き換える
-        holder.discountTextview.setText(String.format(Locale.getDefault(),"%d%%",localData.get(position).getDiscountPer()));
-        holder.discountPriceTextview.setText(String.format(Locale.getDefault(),"%,d円",localData.get(position).getDiscountPrice()));
-        holder.priceTextview.setText(String.format(Locale.getDefault(),"%,d円",localData.get(position).getAfterPrice()));
+        holder.discountTextview.setText(String.format(Locale.getDefault(), "%d%%", data.getDiscountPer()));
+        holder.discountPriceTextview.setText(String.format(Locale.getDefault(), "%,d円", data.getDiscountPrice()));
+        holder.priceTextview.setText(String.format(Locale.getDefault(), "%,d円", data.getAfterPrice()));
         // 文字のGravityを変更(右寄せ)
         holder.discountTextview.setGravity(Gravity.END);
         holder.discountPriceTextview.setGravity(Gravity.END);
@@ -97,17 +90,8 @@ public class ResultLayoutAdapter extends ListAdapter<DiscountData,ResultLayoutAd
         }
 
     }
-    // データセットのサイズを返す (レイアウトマネージャによって呼び出される)
     @Override
-    public int getItemCount() {
-        return localData.size();
-    }
 
-    //
-    public void updateItem(ArrayList<DiscountData> data){
-        localData=data;
-        // localDataのサイズ分の変更をobserverに通知
-        notifyItemRangeChanged(0,getItemCount());
     }
 
     private void applySize(TextView textView,Point size){
@@ -116,6 +100,11 @@ public class ResultLayoutAdapter extends ListAdapter<DiscountData,ResultLayoutAd
         lp.width = size.x;
         lp.height=size.y;
         textView.setLayoutParams(lp);
+    }
+
+    @Override
+    protected DiscountData getItem(int position) {
+        return super.getItem(position);
     }
 
 

--- a/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
@@ -3,29 +3,33 @@ package com.example.discountcalc.customAdapters;
 import android.graphics.Point;
 import android.view.Gravity;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.ListAdapter;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.example.discountcalc.databinding.ResultOneCalcViewBinding;
 import com.example.discountcalc.params.DiscountData;
 import com.example.discountcalc.R;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 
 /**
  * 1行分のデータを1行分のViewに設定して生成するクラス
  **/
-public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapter.ResultViewHolder> {
+public class ResultLayoutAdapter extends ListAdapter<DiscountData,ResultLayoutAdapter.ResultViewHolder> {
 
     private ArrayList<DiscountData> localData;
 
     // resultPriceListViewのid,layout_width,Layout_heightを格納
-    private HashMap<Integer,Point> adapterLayoutSize;
+    private final HashMap<Integer, Point> adapterLayoutSize;
+
+    ResultOneCalcViewBinding binding;
 
     /**
      * 1行分のViewの参照を保持するホルダークラス
@@ -36,24 +40,14 @@ public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapte
         private final TextView priceTextview;
 
         //ビューホルダー
-        public ResultViewHolder(View view){
-            super(view);
-            discountTextview =view.findViewById(R.id.discountLabel);
-            discountPriceTextview =view.findViewById(R.id.discountPriceLabel);
-            priceTextview =view.findViewById(R.id.priceLabel);
+        public ResultViewHolder(ResultOneCalcViewBinding binding) {
+            super(binding.getRoot());
+
+            discountTextview = binding.discountLabel;
+            discountPriceTextview = binding.discountPriceLabel;
+            priceTextview = binding.priceLabel;
         }
 
-        public TextView getDiscountTextview(){
-            return  discountTextview;
-        }
-
-        public TextView getDiscountPriceTextview() {
-            return discountPriceTextview;
-        }
-
-        public TextView getPriceTextview() {
-            return priceTextview;
-        }
     }
 
     /*
@@ -78,9 +72,9 @@ public class ResultLayoutAdapter extends RecyclerView.Adapter<ResultLayoutAdapte
     @Override
     public ResultViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         // リスト項目のUIを定義する新しいビューを作成する。
-        View inflate = LayoutInflater.from(parent.getContext())
-                .inflate(R.layout.result_one_calc_view,parent,false);
-        return new ResultViewHolder(inflate);
+        LayoutInflater inflate = LayoutInflater.from(parent.getContext());
+        binding = ResultOneCalcViewBinding.inflate(inflate,parent,false);
+        return new ResultViewHolder(binding);
     }
 
     // ビューの内容を置き換える(レイアウトマネージャーによって呼び出される)

--- a/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/ResultLayoutAdapter.java
@@ -1,6 +1,7 @@
 package com.example.discountcalc.customAdapters;
 
 import android.graphics.Point;
+import android.os.Bundle;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
@@ -8,6 +9,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.ListAdapter;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -29,6 +31,10 @@ public class ResultLayoutAdapter extends ListAdapter<DiscountData,ResultLayoutAd
     private final HashMap<Integer, Point> adapterLayoutSize;
 
     ResultOneCalcViewBinding binding;
+
+    private static final String payload_discountPer="discountPer";
+    private static final String payload_discountPrice="discountPrice";
+    private static final String payload_AfterPrice="afterPrice";
 
     /**
      * 1行分のViewの参照を保持するホルダークラス
@@ -90,7 +96,34 @@ public class ResultLayoutAdapter extends ListAdapter<DiscountData,ResultLayoutAd
         }
 
     }
+
+    // ビューの内容を置き換える(レイアウトマネージャーによって呼び出される)
     @Override
+    public void onBindViewHolder(@NonNull ResultViewHolder holder, int position,@NonNull List<Object> payloads) {
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads);
+            return;
+        }
+        for (Object payload:payloads){
+            if(payload instanceof Bundle diff){
+
+                // この位置のデータセットから要素を取得し、ビューの内容をその要素で置き換える
+                holder.discountTextview.setText(String.format(Locale.getDefault(), "%d%%", diff.getInt(payload_discountPer)));
+                holder.discountPriceTextview.setText(String.format(Locale.getDefault(), "%,d円", diff.getInt(payload_discountPrice)));
+                holder.priceTextview.setText(String.format(Locale.getDefault(), "%,d円", diff.getInt(payload_AfterPrice)));
+                // 文字のGravityを変更(右寄せ)
+                holder.discountTextview.setGravity(Gravity.END);
+                holder.discountPriceTextview.setGravity(Gravity.END);
+                holder.priceTextview.setGravity(Gravity.END);
+
+                // ヘッダーのサイズに合わせる
+                if(adapterLayoutSize !=null){
+                    applySize(holder.discountTextview,adapterLayoutSize.get(R.id.discountLabel));
+                    applySize(holder.discountPriceTextview,adapterLayoutSize.get(holder.discountPriceTextview.getId()));
+                    applySize(holder.priceTextview,adapterLayoutSize.get(holder.priceTextview.getId()));
+                }
+            }
+        }
 
     }
 
@@ -103,9 +136,41 @@ public class ResultLayoutAdapter extends ListAdapter<DiscountData,ResultLayoutAd
     }
 
     @Override
+    public void submitList(@Nullable List<DiscountData> list) {
+        super.submitList(list);
+    }
+
+    @Override
     protected DiscountData getItem(int position) {
         return super.getItem(position);
     }
 
+    static final DiffUtil.ItemCallback<DiscountData> DIFF_CALLBACK =
+            new DiffUtil.ItemCallback<>() {
+                @Override
+                public boolean areItemsTheSame(@NonNull DiscountData oldItem, @NonNull DiscountData newItem) {
+                    return oldItem.getDiscountPer() == newItem.getDiscountPer();
+                }
 
+                @Override
+                public boolean areContentsTheSame(@NonNull DiscountData oldItem, @NonNull DiscountData newItem) {
+                    return oldItem.equals(newItem);
+                }
+
+                @Nullable
+                @Override
+                public Object getChangePayload(@NonNull DiscountData oldItem, @NonNull DiscountData newItem) {
+                    Bundle diff=new Bundle();
+
+                    diff.putInt(payload_discountPer,newItem.getDiscountPer());
+                    if(oldItem.getDiscountPrice()!= newItem.getDiscountPrice()){
+                        diff.putInt(payload_discountPrice,newItem.getDiscountPrice());
+                    }
+                    if(oldItem.getAfterPrice() != newItem.getAfterPrice()) {
+                        diff.putInt(payload_AfterPrice,newItem.getAfterPrice());
+                    }
+                    if(diff.isEmpty())return null;
+                    return diff;
+                }
+            };
 }

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -100,6 +100,8 @@ public class ResultListFragment extends Fragment {
         // 読み込みUI表示
         progressBarView.setVisibility(View.VISIBLE);
         viewModelInitialize();
+        livedataInit();
+
     }
 
     @Override
@@ -113,8 +115,6 @@ public class ResultListFragment extends Fragment {
         loadSettingData();
 
         recyclerInit();
-
-        LivedataInit();
 
         if (progressBarView != null) {
             progressBarView.setVisibility(View.GONE);
@@ -158,7 +158,7 @@ public class ResultListFragment extends Fragment {
     }
 
     // ユーザー入力した数値が変更された時の処理
-    private void LivedataInit() {
+    private void livedataInit() {
         // LiveData設定
         final Observer<Integer> priceObserver = integer -> {
             // 入力した数値をbeforePriceに適用

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -132,17 +132,14 @@ public class ResultListFragment extends Fragment {
                     // 1度でいいので破棄
                     resultOneCalcLabelView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
 
-        resultLayoutAdapter = new ResultLayoutAdapter(resultDataList, getOneCalcViewLayoutWidthAndHeight());
+                    resultLayoutAdapter = new ResultLayoutAdapter(getOneCalcViewLayoutWidthAndHeight());
 
                     // 縦方向のLayoutManagerを作成
                     LinearLayoutManager llm = new LinearLayoutManager(resultPriceListBinding.getRoot().getContext());
-                    recyclerView.setHasFixedSize(true);
+                    //recyclerView.setHasFixedSize(true);
                     recyclerView.setLayoutManager(llm);
                     recyclerView.setAdapter(resultLayoutAdapter);
-
-                    if(!resultDataList.isEmpty()){
-                        resultLayoutAdapter.updateItem(resultDataList);
-                    }
+                    resultLayoutAdapter.submitList(new ArrayList<>(resultDataList));
                 }
             }
         });
@@ -237,7 +234,7 @@ public class ResultListFragment extends Fragment {
         }
         if (resultLayoutAdapter != null) {
             // アダプタに最新の計算結果をupdate
-            resultLayoutAdapter.updateItem(resultDataList);
+            resultLayoutAdapter.submitList(new ArrayList<>(resultDataList));
         }
     }
 

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -149,7 +149,7 @@ public class ResultListFragment extends Fragment {
     private void viewModelInitialize() {
         // ActivityにこのFragmentが追加されているかチェック
         if (this.getActivity() == null) return;
-        discountCalcViewModel = new ViewModelProvider(this).get(DiscountCalcViewModel.class);
+        discountCalcViewModel = new ViewModelProvider(requireActivity()).get(DiscountCalcViewModel.class);
         customPreferenceListViewModel = new ViewModelProvider(this, new CustomPreferenceListViewModelFactory(requireActivity().getApplication()))
                 .get(CustomPreferenceListViewModel.class);
     }
@@ -180,15 +180,15 @@ public class ResultListFragment extends Fragment {
                 refreshCalc();
             }
             case Custom -> {
-                if (customPreferenceListViewModel.PreferenceParamList()==null) {
+                if (customPreferenceListViewModel.PreferenceParamList() == null) {
                     createDiscountPreferenceData();
                     break;
                 }
-                customPreferenceListViewModel.AllPreferenceParamList().observe(getViewLifecycleOwner(),params->{
-                    customPreferenceListViewModel.usePreferenceParamList(preferences.getString(getString(R.string.using_custom_preference),""));
+                customPreferenceListViewModel.AllPreferenceParamList().observe(getViewLifecycleOwner(), params -> {
+                    customPreferenceListViewModel.usePreferenceParamList(preferences.getString(getString(R.string.using_custom_preference), ""));
                 });
 
-                customPreferenceListViewModel.PreferenceParamList().observe(getViewLifecycleOwner(),param->{
+                customPreferenceListViewModel.PreferenceParamList().observe(getViewLifecycleOwner(), param -> {
                     // 割引率リストをクリアしておく
                     discountPerList.clear();
                     for (int i = 0; i < customPreferenceListViewModel.preferenceParamListSize(); i++) {
@@ -205,11 +205,11 @@ public class ResultListFragment extends Fragment {
         preferences=PreferenceManager.getDefaultSharedPreferences(this.requireContext());
 
         // 表示数取得
-        viewCount=preferences.getInt(getString(R.string.view_count),DEFAULT_VIEWCOUNT);
+        viewCount = preferences.getInt(getString(R.string.view_count), DEFAULT_VIEWCOUNT);
 
-        String useKey=getString(R.string.using_setting);
+        String useKey = getString(R.string.using_setting);
         // SharedPreferencesに保存された設定キー取得しセット。存在しない場合はNone
-        String settingType=preferences.getString(useKey,DiscountType.None.name());
+        String settingType = preferences.getString(useKey, DiscountType.None.name());
         discountType = DiscountType.valueOf(settingType);
     }
 
@@ -217,7 +217,7 @@ public class ResultListFragment extends Fragment {
     private void calcDiscounts() {
         resultDataList.clear();
         // ローカル変数を使用することでviewCountを直接操作しなくても表示数調整できるように
-        int displayViewCount=viewCount;
+        int displayViewCount = viewCount;
         // 表示数が利用する割引率のリストよりも大きければ、利用する割引率のリストに合わせる。OutOfBoundsの防止
         if (displayViewCount > discountPerList.size()) displayViewCount = discountPerList.size();
         for (int i = 0; i < displayViewCount; i++) {
@@ -239,8 +239,8 @@ public class ResultListFragment extends Fragment {
     }
 
     // 再計算用メソッド
-    private void refreshCalc(){
-        if(discountPerList ==null || discountPerList.isEmpty()){
+    private void refreshCalc() {
+        if (discountPerList == null || discountPerList.isEmpty()) {
             return;
         }
         calcDiscounts();
@@ -250,25 +250,25 @@ public class ResultListFragment extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
-        boolean isSaveFlag=preferences.getBoolean(getString(R.string.is_save_parameters),false);
+        boolean isSaveFlag = preferences.getBoolean(getString(R.string.is_save_parameters), false);
         // パラメータ保存をしない設定であれば保存処理を実行しない。
-        if(!isSaveFlag) return;
+        if (!isSaveFlag) return;
 
         // 一時中断で保存しておく
-        boolean isSave=saveDataStore();
-        Log.i("settingSave",String.valueOf(isSave));
+        boolean isSave = saveDataStore();
+        Log.i("settingSave", String.valueOf(isSave));
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-        boolean isSaveFlag=preferences.getBoolean(getString(R.string.is_save_parameters),false);
+        boolean isSaveFlag = preferences.getBoolean(getString(R.string.is_save_parameters), false);
         // パラメータ保存をしない設定であれば保存処理を実行しない。
-        if(!isSaveFlag) return;
+        if (!isSaveFlag) return;
 
         // Fragmentが削除された際に保存しておく
-        boolean isSave=saveDataStore();
-        Log.i("settingSave",String.valueOf(isSave));
+        boolean isSave = saveDataStore();
+        Log.i("settingSave", String.valueOf(isSave));
     }
 
     // あらかじめ用意された割引率取得し、一覧データに使用する割引率を設定する。
@@ -281,11 +281,11 @@ public class ResultListFragment extends Fragment {
             discountPerList.add(discountData[i]);
         }
         // 使用する割引率設定をプリセットに指定して保存しておく。
-        discountType=DiscountType.Preset;
+        discountType = DiscountType.Preset;
 
         // 使用する割引率設定を更新しておく。
-        String saveKey=getString(R.string.using_setting);
-        preferences.edit().putString(saveKey,discountType.toString()).apply();
+        String saveKey = getString(R.string.using_setting);
+        preferences.edit().putString(saveKey, discountType.toString()).apply();
     }
 
     private HashMap<Integer, Point> getOneCalcViewLayoutWidthAndHeight() {

--- a/app/src/main/java/com/example/discountcalc/params/DiscountData.java
+++ b/app/src/main/java/com/example/discountcalc/params/DiscountData.java
@@ -1,5 +1,7 @@
 package com.example.discountcalc.params;
 
+import androidx.annotation.Nullable;
+
 public class DiscountData {
 
     // 割引率
@@ -53,5 +55,18 @@ public class DiscountData {
 
     public int getConfigEnum() {
         return configEnum;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean equals = false;
+        if (obj instanceof DiscountData data) {
+            if (this.discountPer == data.discountPer &&
+                    this.discountPrice == data.discountPrice &&
+                    this.afterPrice == data.afterPrice) {
+                equals = true;
+            }
+        }
+        return equals;
     }
 }


### PR DESCRIPTION
- RecyclerViewをListAdapterに改修
- リストが更新できない原因となっていた&特に使用する必要がなかったのでlocalDataフィールドを削除。
　localDataを利用していたメソッドと処理を削除。値の参照はgetItemメソッドをオーバーライドして、その戻り値を使用
- DiffUtilを実装。payloadを利用した差分更新処理
- Fragment側からの呼び出しをDiffUtilに合わせたものに修正。
- ユーザーが入力した金額の変更通知を受け取れていなかった問題があった為修正。