### PR TITLE
OnGlobalLayoutListenerの登録位置をOnViewCreatedに修正。メモリリークを防ぐため

### DIFF
--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -126,6 +126,9 @@ public class ResultListFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        if(resultOneCalcLabelView!=null&&globalLayoutListener!=null){
+        resultOneCalcLabelView.getViewTreeObserver().removeOnGlobalLayoutListener(globalLayoutListener);
+        }
         resultLayoutAdapter=null;
         resultPriceListBinding=null;
     }

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -121,6 +121,13 @@ public class ResultListFragment extends Fragment {
         }
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        resultLayoutAdapter=null;
+        resultPriceListBinding=null;
+    }
+
     private void recyclerInit() {
 
         // 描画完了後の通知を受け取って、その地点のHashMapを作成

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -101,6 +101,7 @@ public class ResultListFragment extends Fragment {
         progressBarView.setVisibility(View.VISIBLE);
         viewModelInitialize();
         livedataInit();
+        recyclerInit();
 
     }
 
@@ -114,7 +115,6 @@ public class ResultListFragment extends Fragment {
         // 保存データ取得
         loadSettingData();
 
-        recyclerInit();
 
         if (progressBarView != null) {
             progressBarView.setVisibility(View.GONE);

--- a/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
+++ b/app/src/main/java/com/example/discountcalc/fragments/ResultListFragment.java
@@ -58,6 +58,8 @@ public class ResultListFragment extends Fragment {
     private RecyclerView recyclerView;
     private ResultLayoutAdapter resultLayoutAdapter;
 
+    private ViewTreeObserver.OnGlobalLayoutListener globalLayoutListener;
+
     DiscountCalcViewModel discountCalcViewModel;
 
     // カスタム設定データのViewModel
@@ -129,9 +131,7 @@ public class ResultListFragment extends Fragment {
     }
 
     private void recyclerInit() {
-
-        // 描画完了後の通知を受け取って、その地点のHashMapを作成
-        resultOneCalcLabelView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+        globalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
                 View checkView=resultOneCalcLabelView.findViewById(R.id.discountLabel);
@@ -149,7 +149,9 @@ public class ResultListFragment extends Fragment {
                     resultLayoutAdapter.submitList(new ArrayList<>(resultDataList));
                 }
             }
-        });
+        };
+        // 描画完了後の通知を受け取って、その地点のHashMapを作成
+        resultOneCalcLabelView.getViewTreeObserver().addOnGlobalLayoutListener(globalLayoutListener);
     }
 
 


### PR DESCRIPTION
OnStartだとイベントが多重に登録されてしまうことがあるようなのでOnViewCreatedに移動。