### PR TITLE
#93 の対応

### DIFF
--- a/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
@@ -84,7 +84,7 @@ public class CustomPreferenceListAdapter
                         viewModel.updatePreferenceData(adapterPosition, newPreferenceData);
                     } catch (NumberFormatException ex) {
                         binding.customPreferenceOneLineNum.setText(String.valueOf(beforePer));
-                        throw new RuntimeException("CustomPreferenceListViewHolder.bind:" + ex);
+                        Log.e("CustomPreferenceListAdapter", String.valueOf(new RuntimeException("CustomPreferenceListViewHolder.bind:" + ex)));
                     }
                 }
             });

--- a/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
@@ -56,24 +56,24 @@ public class CustomPreferenceListAdapter
             binding.setPosition(position);
             binding.setPreferenceParam(preferenceParam);
             binding.setViewModel(viewModel);
-                binding.customPreferenceOneLineNum.setOnFocusChangeListener((v, hasFocus) -> {
-                    if (!hasFocus) {
-                        try {
-                            int newPer = Integer.parseInt(binding.customPreferenceOneLineNum.getText().toString());
-                            int beforePer = viewModel.getPreferenceParamData(position).per();
-                            // 値が変わってなければここで終了
-                            if (newPer == beforePer) return;
+            binding.customPreferenceOneLineNum.setOnFocusChangeListener((v, hasFocus) -> {
+                if (!hasFocus) {
+                    try {
+                        int newPer = Integer.parseInt(binding.customPreferenceOneLineNum.getText().toString());
+                        int beforePer = viewModel.getPreferenceParamData(position).per();
+                        // 値が変わってなければここで終了
+                        if (newPer == beforePer) return;
 
-                            PreferenceParam newPreferenceData = new PreferenceParam(viewModel.getPreferenceParamData(position).uid(),
-                                    viewModel.getPreferenceParamData(position).orderIndex(),
-                                    newPer,
-                                    viewModel.getPreferenceParamData(position).saveName());
-                            viewModel.updatePreferenceData(position, newPreferenceData);
-                        } catch (NumberFormatException ex) {
-                            throw new RuntimeException("CustomPreferenceListViewHolder.bind:" + ex);
-                        }
+                        PreferenceParam newPreferenceData = new PreferenceParam(viewModel.getPreferenceParamData(position).uid(),
+                                viewModel.getPreferenceParamData(position).orderIndex(),
+                                newPer,
+                                viewModel.getPreferenceParamData(position).saveName());
+                        viewModel.updatePreferenceData(position, newPreferenceData);
+                    } catch (NumberFormatException ex) {
+                        throw new RuntimeException("CustomPreferenceListViewHolder.bind:" + ex);
                     }
-                });
+                }
+            });
             binding.executePendingBindings();
         }
 

--- a/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
@@ -68,6 +68,7 @@ public class CustomPreferenceListAdapter
 
                         if (text.isEmpty()) {
                             binding.customPreferenceOneLineNum.setText(String.valueOf(beforePer));
+                            return;
                         }
 
                         // 値が変わってなければここで終了

--- a/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
@@ -84,7 +84,7 @@ public class CustomPreferenceListAdapter
                         viewModel.updatePreferenceData(adapterPosition, newPreferenceData);
                     } catch (NumberFormatException ex) {
                         binding.customPreferenceOneLineNum.setText(String.valueOf(beforePer));
-                        Log.e("CustomPreferenceListAdapter", String.valueOf(new RuntimeException("CustomPreferenceListViewHolder.bind:" + ex)));
+                        Log.e("CustomPreferenceListAdapter", "Failed to parse preference value", ex);
                     }
                 }
             });

--- a/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
+++ b/app/src/main/java/com/example/discountcalc/customAdapters/CustomPreferenceListAdapter.java
@@ -58,18 +58,31 @@ public class CustomPreferenceListAdapter
             binding.setViewModel(viewModel);
             binding.customPreferenceOneLineNum.setOnFocusChangeListener((v, hasFocus) -> {
                 if (!hasFocus) {
+                    //　アダプターに対する相対位置を取得
+                    int adapterPosition = getBindingAdapterPosition();
+                    if (adapterPosition == RecyclerView.NO_POSITION) return;
+
+                    int beforePer = viewModel.getPreferenceParamData(adapterPosition).per();
                     try {
-                        int newPer = Integer.parseInt(binding.customPreferenceOneLineNum.getText().toString());
-                        int beforePer = viewModel.getPreferenceParamData(position).per();
+                        String text = binding.customPreferenceOneLineNum.getText().toString();
+
+                        if (text.isEmpty()) {
+                            binding.customPreferenceOneLineNum.setText(String.valueOf(beforePer));
+                        }
+
                         // 値が変わってなければここで終了
+                        int newPer = Integer.parseInt(text);
                         if (newPer == beforePer) return;
 
-                        PreferenceParam newPreferenceData = new PreferenceParam(viewModel.getPreferenceParamData(position).uid(),
-                                viewModel.getPreferenceParamData(position).orderIndex(),
+                        PreferenceParam newPreferenceData = new PreferenceParam(
+                                viewModel.getPreferenceParamData(adapterPosition).uid(),
+                                viewModel.getPreferenceParamData(adapterPosition).orderIndex(),
                                 newPer,
-                                viewModel.getPreferenceParamData(position).saveName());
-                        viewModel.updatePreferenceData(position, newPreferenceData);
+                                viewModel.getPreferenceParamData(adapterPosition).saveName()
+                        );
+                        viewModel.updatePreferenceData(adapterPosition, newPreferenceData);
                     } catch (NumberFormatException ex) {
+                        binding.customPreferenceOneLineNum.setText(String.valueOf(beforePer));
                         throw new RuntimeException("CustomPreferenceListViewHolder.bind:" + ex);
                     }
                 }


### PR DESCRIPTION
非同期で古いインデックスを指したままの処理にならないよう、getBindingAdapterPositionを使用したアイテム位置取得に変更。
例外スロー時のテキスト処理を追加